### PR TITLE
Add Vim instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,35 @@ This repository contains schemata for:
 }
 ```
 
+## Installation in Vim
+
+1. Install the [coc.nvim](https://github.com/neoclide/coc.nvim) plugin
+2. Install [coc-yaml](https://github.com/neoclide/coc-yaml): `:CocInstall coc-yaml`
+3. Add schema to `coc-settings.json` (`:CocConfig`):
+```json
+{    
+    "yaml.schemas": {
+        "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/dbt_yml_files.json": [
+            "/**/*.yml",
+            "!profiles.yml",
+            "!dbt_project.yml",
+            "!packages.yml",
+            "!selectors.yml",
+            "!profile_template.yml"
+        ],
+        "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/dbt_project.json": [
+            "dbt_project.yml"
+        ],
+        "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/selectors.json": [
+            "selectors.yml"
+        ],
+        "https://raw.githubusercontent.com/dbt-labs/dbt-jsonschema/main/schemas/packages.json": [
+            "packages.yml"
+        ]
+    },
+}
+```
+
 _Do you use a different IDE which also supports JSON Schema? Please open a PR with setup instructions and links to any extensions!_
 
 ## Contributing 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This repository contains schemata for:
 
 1. Install the [coc.nvim](https://github.com/neoclide/coc.nvim) plugin
 2. Install [coc-yaml](https://github.com/neoclide/coc-yaml): `:CocInstall coc-yaml`
-3. Add schema to `coc-settings.json` (`:CocConfig`):
+3. Add JSON Schema (there might be a better way to do this, but adding directly to `coc-settings.json` using `:CocConfig` works):
 ```json
 {    
     "yaml.schemas": {


### PR DESCRIPTION
This adds instructions for installing in Vim. Unfortunately I couldn't figure out how to reference `.vscode/settings.json` from within the `coc-settings.json` file. Doing so would allow for Vim users to use the same file as VS Codes users, in the same dbt project. Here's a screen capture showing how it works:

https://user-images.githubusercontent.com/5216684/187760374-997ea385-b349-4753-b41c-dfef3af969bc.mov

