### PR TITLE
Fix model validation, add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: install avj
         run: npm install --no-save ajv-cli@5.0.0
       - name: validate all schema files
-        run: find ./schemas -name "*.json" | xargs -n 1 -I {} npx ajv-cli compile -s {} --strict=false --spec=draft7
+        run: find ./schemas -name "*.json" | xargs -n 1 -I {} npx ajv-cli compile -s {} --strict=false
   test-against-sample-dbt-files:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on: pull_request
+
+jobs:
+  validate-json-schemas:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: install avj
+        run: npm install --no-save ajv-cli@5.0.0
+      - name: validate all schema files
+        run: find ./schemas -name "*.json" | xargs -n 1 -I {} npx ajv-cli compile -s {} --strict=false --spec=draft7
+  test-against-sample-dbt-files:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: install avj
+        run: npm install --no-save ajv-cli@5.0.0
+      - name: validate dbt_project.yml sample file
+        run: npx ajv-cli validate -s schemas/dbt_project.json -d tests/dbt_project.yml
+      - name: validate sample model YAML file
+        run: npx ajv-cli validate -s schemas/dbt_yml_files.json -d tests/schema.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+node_modules/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,8 @@
             "!dbt_project.yml",
             "!packages.yml",
             "!selectors.yml",
-            "!profile_template.yml"
+            "!profile_template.yml",
+            "!/.github/**/*.yml"
         ],
         "./schemas/dbt_project.json": [
             "dbt_project.yml"

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -1,5 +1,6 @@
 {
     "title": "dbt_project",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
         "name",

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -1,6 +1,6 @@
 {
     "title": "dbt_project",
-    "$schema": "https://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
         "name",

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -131,7 +131,7 @@
             "oneOf": [
                 {
                     "type": "string",
-                    "pattern": "{{.*}}"
+                    "pattern": "\\{\\{.*\\}\\}"
                 },
                 {
                     "type": "boolean"

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -531,7 +531,9 @@
         },
         "column_properties": {
             "type": "object",
-            "required": "name",
+            "required": [
+                "name"
+            ],
             "properties": {
                 "name": {
                     "type": "string"
@@ -615,7 +617,7 @@
         },
         "jinja_string": {
             "type": "string",
-            "pattern": "{{.*}}"
+            "pattern": "\\{\\{.*\\}\\}"
         },
         "number_or_jinja_string": {
             "oneOf": [

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -1,5 +1,6 @@
 {
     "title": "dbt_yml_files",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
         "version"

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -1,6 +1,6 @@
 {
     "title": "dbt_yml_files",
-    "$schema": "https://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
         "version"

--- a/schemas/packages.json
+++ b/schemas/packages.json
@@ -1,6 +1,6 @@
 {
     "title": "packages",
-    "$schema": "https://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
         "packages"

--- a/schemas/packages.json
+++ b/schemas/packages.json
@@ -1,5 +1,6 @@
 {
     "title": "packages",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
         "packages"

--- a/schemas/selectors.json
+++ b/schemas/selectors.json
@@ -1,5 +1,6 @@
 {
     "title": "selectors",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
         "selectors"

--- a/schemas/selectors.json
+++ b/schemas/selectors.json
@@ -1,6 +1,6 @@
 {
     "title": "selectors",
-    "$schema": "https://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
         "selectors"

--- a/schemas/selectors.json
+++ b/schemas/selectors.json
@@ -20,7 +20,7 @@
                         "oneOf": [
                             {
                                 "type": "string",
-                                "pattern": "{{.*}}"
+                                "pattern": "\\{\\{.*\\}\\}"
                             },
                             {
                                 "type": "boolean"

--- a/tests/dbt_project.yml
+++ b/tests/dbt_project.yml
@@ -1,4 +1,4 @@
-# this file was generated with dbt init with DBT 1.2.1
+# this file was generated with dbt init with dbt 1.2.1
 
 # Name your project! Project names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's

--- a/tests/dbt_project.yml
+++ b/tests/dbt_project.yml
@@ -1,0 +1,39 @@
+# this file was generated with dbt init with DBT 1.2.1
+
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: 'test'
+version: '1.0.0'
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: 'test'
+
+# These configurations specify where dbt should look for different types of files.
+# The `model-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+model-paths: ["models"]
+analysis-paths: ["analyses"]
+test-paths: ["tests"]
+seed-paths: ["seeds"]
+macro-paths: ["macros"]
+snapshot-paths: ["snapshots"]
+
+target-path: "target"  # directory which will store compiled SQL files
+clean-targets:         # directories to be removed by `dbt clean`
+  - "target"
+  - "dbt_packages"
+
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the `{{ config(...) }}` macro.
+models:
+  test:
+    # Config indicated by + and applies to all files under models/example/
+    example:
+      +materialized: view

--- a/tests/schema.yml
+++ b/tests/schema.yml
@@ -1,4 +1,4 @@
-# this file was generated with dbt init with DBT 1.2.1
+# this file was generated with dbt init with dbt 1.2.1
 
 version: 2
 

--- a/tests/schema.yml
+++ b/tests/schema.yml
@@ -1,0 +1,22 @@
+# this file was generated with dbt init with DBT 1.2.1
+
+version: 2
+
+models:
+  - name: my_first_dbt_model
+    description: "A starter dbt model"
+    columns:
+      - name: id
+        description: "The primary key for this table"
+        tests:
+          - unique
+          - not_null
+
+  - name: my_second_dbt_model
+    description: "A starter dbt model"
+    columns:
+      - name: id
+        description: "The primary key for this table"
+        tests:
+          - unique
+          - not_null


### PR DESCRIPTION
When trying to use these schemas in a CI workflow with our DBT project, I ran into a few errors with the JSON schema documents with both [Ajv](https://ajv.js.org/) and [jsonschema](https://python-jsonschema.readthedocs.io/en/stable/).

This has a couple of fixes that allowed the schemas themselves to be validated as draft 7. (I used draft 7 since it's the most common from my experience, but it might also be good to add a `$schema` entry to the files). There's also a sample GitHub Actions CI workflow that tests using ajv-cli:
1. If the schema files pass draft7
2. Testing simple `dbt_project.yml` and `model.yml` files generated with `dbt init`.

Here's a run on my fork: https://github.com/kochalex/dbt-jsonschema/actions/runs/3048375813

<img width="828" alt="Screen Shot 2022-09-13 at 4 22 48 PM" src="https://user-images.githubusercontent.com/3217653/190011754-7b686306-1602-4fd9-a09c-5c20324480c4.png">

Separately, are there any plans for DBT to publish these schemas in a registry like https://schemas.getdbt.com/ or have them officially part of DBT?

I've pointed my VS Code at these updated files and our project's YAML files validate ok, but it should be noted that the existing files also seemed to work ok with the VS Code YAML extension, it was just the CI cases that failed (with two separate validators). I know CI is not the intended use case here. 😸 