### PR TITLE
Add BQ specific configurations

### DIFF
--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -139,6 +139,18 @@
                 }
             ]
         },
+        "label_configs": {
+            "title": "Label configs",
+            "type": "object",
+            "description": "Configurations specific to Big Query adapter used to add labels and tags to tables & views created by dbt.",
+            "patternProperties": {
+                "^[a-z][a-z0-9_-]{0,63}$": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9_-]{0,64}$"
+                }
+            },
+            "additionalProperties": false
+        },
         "model_configs": {
             "title": "Model configs",
             "type": "object",
@@ -154,8 +166,19 @@
                 "+enabled": {
                     "$ref": "#/$defs/boolean_or_jinja_string"
                 },
+                "+hours_to_expiration": {
+                    "type": "number",
+                    "description": "Configuration specific to Big Query adapter used to set an expiration delay (in hours) to a table."
+                },
                 "+incremental_strategy": {
                     "type": "string"
+                },
+                "+kms_key_name": {
+                    "type": "string",
+                    "description": "Configuration, specific to Big Query adapter, of the KMS key name used for data encryption."
+                },
+                "+labels": {
+                    "$ref": "#/$defs/label_configs"
                 },
                 "+materialized": {
                     "type": "string"

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -142,7 +142,7 @@
         "label_configs": {
             "title": "Label configs",
             "type": "object",
-            "description": "Configurations specific to Big Query adapter used to add labels and tags to tables & views created by dbt.",
+            "description": "Configurations specific to BigQuery adapter used to add labels and tags to tables & views created by dbt.",
             "patternProperties": {
                 "^[a-z][a-z0-9_-]{0,63}$": {
                     "type": "string",
@@ -169,7 +169,7 @@
                 "+grant_access_to": {
                     "title": "Authorized views",
                     "type": "array",
-                    "description": "Configuration, specific to Big Query adapter, used to setup authorized views.",
+                    "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
                     "items": {
                         "type": "object",
                         "properties": {
@@ -184,14 +184,14 @@
                 },
                 "+hours_to_expiration": {
                     "type": "number",
-                    "description": "Configuration specific to Big Query adapter used to set an expiration delay (in hours) to a table."
+                    "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
                 },
                 "+incremental_strategy": {
                     "type": "string"
                 },
                 "+kms_key_name": {
                     "type": "string",
-                    "description": "Configuration, specific to Big Query adapter, of the KMS key name used for data encryption."
+                    "description": "Configuration, specific to BigQuery adapter, of the KMS key name used for data encryption."
                 },
                 "+labels": {
                     "$ref": "#/$defs/label_configs"

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -179,7 +179,8 @@
                             "project": {
                                 "type": "string"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "+hours_to_expiration": {

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -166,6 +166,22 @@
                 "+enabled": {
                     "$ref": "#/$defs/boolean_or_jinja_string"
                 },
+                "+grant_access_to": {
+                    "title": "Authorized views",
+                    "type": "array",
+                    "description": "Configuration, specific to Big Query adapter, used to setup authorized views.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "database": {
+                                "type": "string"
+                            },
+                            "project": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "+hours_to_expiration": {
                     "type": "number",
                     "description": "Configuration specific to Big Query adapter used to set an expiration delay (in hours) to a table."

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -314,6 +314,26 @@
                             }
                         }
                     },
+                    "hours_to_expiration": {
+                        "type": "number",
+                        "description": "Configuration specific to Big Query adapter used to set an expiration delay (in hours) to a table."
+                    },
+                    "kms_key_name": {
+                        "type": "string",
+                        "description": "Configuration of the KMS key name, specific to Big Query adapter."
+                    },
+                    "labels": {
+                        "title": "Label configs",
+                        "type": "object",
+                        "description": "Configuration specific to Big Query adapter used to add labels and tags to tables/views created by dbt.",
+                        "patternProperties": {
+                            "^[a-z][a-z0-9]{0,63}$": {
+                                "type": "string",
+                                "pattern": "^[a-z0-9_-]{0,64}$"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
                     "tests": {
                         "type": "array",
                         "items": {
@@ -547,6 +567,14 @@
                 },
                 "meta": {
                     "type": "object"
+                },
+                "policy_tags": {
+                    "title": "Policy tags",
+                    "type": "array",
+                    "description": "Configurations, specific to Big Query adapter, used to set policy tags on specific columns, enabling column-level security.",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "quote": {
                     "$ref": "#/$defs/boolean_or_jinja_string"

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -571,7 +571,7 @@
                 "policy_tags": {
                     "title": "Policy tags",
                     "type": "array",
-                    "description": "Configurations, specific to Big Query adapter, used to set policy tags on specific columns, enabling column-level security.",
+                    "description": "Configurations, specific to Big Query adapter, used to set policy tags on specific columns, enabling column-level security. Only relevant when `persist_docs.columns` is true.",
                     "items": {
                         "type": "string"
                     }

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -327,7 +327,8 @@
                                 "project": {
                                     "type": "string"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
                     },
                     "hours_to_expiration": {

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -317,7 +317,7 @@
                     "grant_access_to": {
                         "title": "Authorized views",
                         "type": "array",
-                        "description": "Configuration, specific to Big Query adapter, used to setup authorized views.",
+                        "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
                         "items": {
                             "type": "object",
                             "properties": {
@@ -332,16 +332,16 @@
                     },
                     "hours_to_expiration": {
                         "type": "number",
-                        "description": "Configuration specific to Big Query adapter used to set an expiration delay (in hours) to a table."
+                        "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
                     },
                     "kms_key_name": {
                         "type": "string",
-                        "description": "Configuration of the KMS key name, specific to Big Query adapter."
+                        "description": "Configuration of the KMS key name, specific to BigQuery adapter."
                     },
                     "labels": {
                         "title": "Label configs",
                         "type": "object",
-                        "description": "Configuration specific to Big Query adapter used to add labels and tags to tables/views created by dbt.",
+                        "description": "Configuration specific to BigQuery adapter used to add labels and tags to tables/views created by dbt.",
                         "patternProperties": {
                             "^[a-z][a-z0-9]{0,63}$": {
                                 "type": "string",
@@ -587,7 +587,7 @@
                 "policy_tags": {
                     "title": "Policy tags",
                     "type": "array",
-                    "description": "Configurations, specific to Big Query adapter, used to set policy tags on specific columns, enabling column-level security. Only relevant when `persist_docs.columns` is true.",
+                    "description": "Configurations, specific to BigQuery adapter, used to set policy tags on specific columns, enabling column-level security. Only relevant when `persist_docs.columns` is true.",
                     "items": {
                         "type": "string"
                     }

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -314,6 +314,22 @@
                             }
                         }
                     },
+                    "grant_access_to": {
+                        "title": "Authorized views",
+                        "type": "array",
+                        "description": "Configuration, specific to Big Query adapter, used to setup authorized views.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "database": {
+                                    "type": "string"
+                                },
+                                "project": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
                     "hours_to_expiration": {
                         "type": "number",
                         "description": "Configuration specific to Big Query adapter used to set an expiration delay (in hours) to a table."


### PR DESCRIPTION
### Description
Add new configurations for the following properties, specific to Big Query adapter (listed [here](https://docs.getdbt.com/reference/resource-configs/bigquery-configs)):
- [x] [`labels` & `policy_tags`](https://docs.getdbt.com/reference/resource-configs/bigquery-configs#labels-and-tags)
- [x] [`hours_to_expiration`](https://docs.getdbt.com/reference/resource-configs/bigquery-configs#controlling-table-expiration)
- [x] [`kms_key_name`](https://docs.getdbt.com/reference/resource-configs/bigquery-configs#managing-kms-encryption)
- [x] [`grant_access_to`](https://docs.getdbt.com/reference/resource-configs/bigquery-configs#authorized-views)

### Related issues
- Closes #18 
- Closes #11