### PR TITLE
Corrections and improvements to the properties of the BQ configuration

### DIFF
--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -295,6 +295,43 @@
                     "config": {
                         "type": "object",
                         "properties": {
+                            "grant_access_to": {
+                                "title": "Authorized views",
+                                "type": "array",
+                                "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "database": {
+                                            "type": "string"
+                                        },
+                                        "project": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                }
+                            },
+                            "hours_to_expiration": {
+                                "type": "number",
+                                "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
+                            },
+                            "kms_key_name": {
+                                "type": "string",
+                                "description": "Configuration of the KMS key name, specific to BigQuery adapter."
+                            },
+                            "labels": {
+                                "title": "Label configs",
+                                "type": "object",
+                                "description": "Configuration specific to BigQuery adapter used to add labels and tags to tables/views created by dbt.",
+                                "patternProperties": {
+                                    "^[a-z][a-z0-9]{0,63}$": {
+                                        "type": "string",
+                                        "pattern": "^[a-z0-9_-]{0,64}$"
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
                             "materialized": {
                                 "type": "string"
                             },
@@ -313,43 +350,6 @@
                                 "type": "boolean"
                             }
                         }
-                    },
-                    "grant_access_to": {
-                        "title": "Authorized views",
-                        "type": "array",
-                        "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "database": {
-                                    "type": "string"
-                                },
-                                "project": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "hours_to_expiration": {
-                        "type": "number",
-                        "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
-                    },
-                    "kms_key_name": {
-                        "type": "string",
-                        "description": "Configuration of the KMS key name, specific to BigQuery adapter."
-                    },
-                    "labels": {
-                        "title": "Label configs",
-                        "type": "object",
-                        "description": "Configuration specific to BigQuery adapter used to add labels and tags to tables/views created by dbt.",
-                        "patternProperties": {
-                            "^[a-z][a-z0-9]{0,63}$": {
-                                "type": "string",
-                                "pattern": "^[a-z0-9_-]{0,64}$"
-                            }
-                        },
-                        "additionalProperties": false
                     },
                     "tests": {
                         "type": "array",

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -301,6 +301,10 @@
                                 "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
                                 "items": {
                                     "type": "object",
+                                    "required": [
+                                        "database",
+                                        "project"
+                                    ],
                                     "properties": {
                                         "database": {
                                             "type": "string"

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -322,7 +322,8 @@
                             },
                             "kms_key_name": {
                                 "type": "string",
-                                "description": "Configuration of the KMS key name, specific to BigQuery adapter."
+                                "description": "Configuration of the KMS key name, specific to BigQuery adapter.",
+                                "pattern": "projects/[a-zA-Z0-9_-]*/locations/[a-zA-Z0-9_-]*/keyRings/.*/cryptoKeys/.*"
                             },
                             "labels": {
                                 "title": "Label configs",


### PR DESCRIPTION
### Description
- [x] Fix the location of BQ config properties introduce in #19. These properties should be under the `config` key and not at the root level of a model entry.
- [x] Flag the properties `database` and `project` of `grant_access_to` as required to have autocompletion.
- [x] Add minimal regular expression to validate the property `kms_key_name`, as described [here](https://cloud.google.com/bigquery/docs/customer-managed-encryption#key_resource_id).

❌ **Before**
```yaml
models:
  - name: my_first_dbt_model
    description: "A starter dbt model"
    labels:
      foo: bar
    grant_access_to:
      - database: a_database
        project: a_project
    kms_key_name: a_key_name
```

:white_check_mark: **After**
```yaml
models:
  - name: my_first_dbt_model
    description: "A starter dbt model"
    config:
      labels:
        foo: bar
      grant_access_to:
        - database: a_database
          project: a_project
      kms_key_name: projects/kms_project_id/locations/location/keyRings/key_ring/cryptoKeys/key
```