### PR TITLE
Add new properties for models, seeds & exposures

### DIFF
--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -201,18 +201,7 @@
                     "type": "string"
                 },
                 "+persist_docs": {
-                    "type": "object",
-                    "properties": {
-                        "columns": {
-                            "$ref": "#/$defs/boolean_or_jinja_string",
-                            "default": true
-                        },
-                        "relation": {
-                            "$ref": "#/$defs/boolean_or_jinja_string",
-                            "default": true
-                        }
-                    },
-                    "additionalProperties": false
+                    "$ref": "#/$defs/persist_docs_config"
                 },
                 "+post-hook": {
                     "$ref": "#/$defs/array_of_strings"
@@ -234,10 +223,29 @@
                 "$ref": "#/$defs/model_configs"
             }
         },
+        "persist_docs_config": {
+            "title": "Persist docs config",
+            "type": "object",
+            "description": "Configurations for the persistence of the dbt documentation.",
+            "properties": {
+                "columns": {
+                    "$ref": "#/$defs/boolean_or_jinja_string",
+                    "default": true
+                },
+                "relation": {
+                    "$ref": "#/$defs/boolean_or_jinja_string",
+                    "default": true
+                }
+            },
+            "additionalProperties": false
+        },
         "seed_configs": {
             "title": "Seed configs",
             "type": "object",
             "properties": {
+                "+persist_docs": {
+                    "$ref": "#/$defs/persist_docs_config"
+                },
                 "+quote_columns": {
                     "$ref": "#/$defs/boolean_or_jinja_string"
                 },

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -361,6 +361,9 @@
                             }
                         }
                     },
+                    "meta": {
+                        "type": "object"
+                    },
                     "tests": {
                         "type": "array",
                         "items": {

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -73,14 +73,19 @@
             "items": {
                 "type": "object",
                 "required": [
+                    "depends_on",
                     "name",
                     "owner",
-                    "depends_on"
+                    "type"
                 ],
                 "$comment": "NB: depends_on is not strictly required, but is _expected_ according to the documentation",
                 "properties": {
                     "name": {
                         "type": "string"
+                    },
+                    "label": {
+                        "type": "string",
+                        "$comment": "Added in dbt Core v1.3"
                     },
                     "type": {
                         "type": "string",


### PR DESCRIPTION
### Description
- [x] Add `persist_docs` config for seeds
- [x] Add `label` in exposures config
- [x] Set `type` as a required key for exposures
- [x] Add `meta` for models config  (closes #17)