### PR TITLE
Add the ability to define `docs` config

### DIFF
--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -363,7 +363,8 @@
             "properties": {
                 "node_color": {
                     "type": "string",
-                    "description": "The color of the node on the DAG in the documentation"
+                    "description": "The color of the node on the DAG in the documentation. It must be an Hex code or a valid CSS color name.",
+                    "pattern": "^(#[a-fA-F0-9]{3}|#[a-fA-F0-9]{6}|[^#][a-zA-Z]*)$"
                 },
                 "show": {
                     "type": "boolean",

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -223,6 +223,9 @@
                 },
                 "+tags": {
                     "$ref": "#/$defs/string_or_array_of_strings"
+                },
+                "+docs": {
+                    "$ref": "#/$defs/docs_config"
                 }
             },
             "additionalProperties": {
@@ -352,6 +355,22 @@
             "additionalProperties": {
                 "$ref": "#/$defs/test_configs"
             }
+        },
+        "docs_config": {
+            "title": "Docs config",
+            "type": "object",
+            "description": "Configurations for the appearance of nodes in the dbt documentation.",
+            "properties": {
+                "node_color": {
+                    "type": "string",
+                    "description": "The color of the node on the DAG in the documentation"
+                },
+                "show": {
+                    "type": "boolean",
+                    "default": true
+                }
+            },
+            "additionalProperties": false
         }
     }
 }


### PR DESCRIPTION
Add the schema for `docs` to define the nodes colors: https://docs.getdbt.com/reference/resource-configs/docs