### PR TITLE
Add `loader` to table-level properties

### DIFF
--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -517,6 +517,9 @@
                                     "type": "string",
                                     "description": "Which column to check during data freshness tests. Only needed if the table has a different loaded_at_field to the one defined on the source overall."
                                 },
+                                "loader": {
+                                    "type": "string"
+                                },
                                 "meta": {
                                     "type": "object"
                                 },


### PR DESCRIPTION
Addresses #28 by adding the `loader` property to the `tables` object, in addition to the `sources`