### PR TITLE
add enabled to seeds as config option

### DIFF
--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -272,6 +272,12 @@
                 "+enabled": {
                     "$ref": "#/$defs/boolean_or_jinja_string"
                 },
+                "+copy_grants": {
+                    "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "+database": {
+                    "type": "string"
+                },
                 "+schema": {
                     "type": "string"
                 },

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -145,6 +145,23 @@
                 }
             ]
         },
+        "docs_config": {
+            "title": "Docs config",
+            "type": "object",
+            "description": "Configurations for the appearance of nodes in the dbt documentation.",
+            "properties": {
+                "node_color": {
+                    "type": "string",
+                    "description": "The color of the node on the DAG in the documentation. It must be an Hex code or a valid CSS color name.",
+                    "pattern": "^(#[a-fA-F0-9]{3}|#[a-fA-F0-9]{6}|[^#][a-zA-Z]*)$"
+                },
+                "show": {
+                    "type": "boolean",
+                    "default": true
+                }
+            },
+            "additionalProperties": false
+        },
         "label_configs": {
             "title": "Label configs",
             "type": "object",
@@ -168,6 +185,9 @@
                 },
                 "+database": {
                     "type": "string"
+                },
+                "+docs": {
+                    "$ref": "#/$defs/docs_config"
                 },
                 "+enabled": {
                     "$ref": "#/$defs/boolean_or_jinja_string"
@@ -214,9 +234,7 @@
                         "ignore",
                         "sync_all_columns"
                     ]
-
                 },
-                
                 "+persist_docs": {
                     "$ref": "#/$defs/persist_docs_config"
                 },
@@ -234,9 +252,6 @@
                 },
                 "+tags": {
                     "$ref": "#/$defs/string_or_array_of_strings"
-                },
-                "+docs": {
-                    "$ref": "#/$defs/docs_config"
                 }
             },
             "additionalProperties": {
@@ -263,20 +278,20 @@
             "title": "Seed configs",
             "type": "object",
             "properties": {
-                "+persist_docs": {
-                    "$ref": "#/$defs/persist_docs_config"
-                },
-                "+quote_columns": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
-                },
-                "+enabled": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
-                },
                 "+copy_grants": {
                     "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+database": {
                     "type": "string"
+                },
+                "+enabled": {
+                    "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "+persist_docs": {
+                    "$ref": "#/$defs/persist_docs_config"
+                },
+                "+quote_columns": {
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+schema": {
                     "type": "string"
@@ -375,23 +390,6 @@
             "additionalProperties": {
                 "$ref": "#/$defs/test_configs"
             }
-        },
-        "docs_config": {
-            "title": "Docs config",
-            "type": "object",
-            "description": "Configurations for the appearance of nodes in the dbt documentation.",
-            "properties": {
-                "node_color": {
-                    "type": "string",
-                    "description": "The color of the node on the DAG in the documentation. It must be an Hex code or a valid CSS color name.",
-                    "pattern": "^(#[a-fA-F0-9]{3}|#[a-fA-F0-9]{6}|[^#][a-zA-Z]*)$"
-                },
-                "show": {
-                    "type": "boolean",
-                    "default": true
-                }
-            },
-            "additionalProperties": false
         }
     }
 }

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -269,6 +269,9 @@
                 "+quote_columns": {
                     "$ref": "#/$defs/boolean_or_jinja_string"
                 },
+                "+enabled": {
+                    "$ref": "#/$defs/boolean_or_jinja_string"
+                },
                 "+schema": {
                     "type": "string"
                 },

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -397,12 +397,21 @@
                             "column_types": {
                                 "type": "object"
                             },
+                            "copy_grants": {
+                                "$ref": "#/$defs/boolean_or_jinja_string"
+                            },
+                            "database": {
+                                "typ": "string"
+                            },
                             "enabled": {
                                 "$ref": "#/$defs/boolean_or_jinja_string"
                             },
                             "quote_columns": {
                                 "$ref": "#/$defs/boolean_or_jinja_string"
-                            }
+                            },
+                            "schema": {
+                                "type": "string"
+                            },
                         }
                     },
                     "description": {

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -397,6 +397,9 @@
                             "column_types": {
                                 "type": "object"
                             },
+                            "enabled": {
+                                "$ref": "#/$defs/boolean_or_jinja_string"
+                            },
                             "quote_columns": {
                                 "$ref": "#/$defs/boolean_or_jinja_string"
                             }

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -411,7 +411,7 @@
                             },
                             "schema": {
                                 "type": "string"
-                            },
+                            }
                         }
                     },
                     "description": {

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -401,7 +401,7 @@
                                 "$ref": "#/$defs/boolean_or_jinja_string"
                             },
                             "database": {
-                                "typ": "string"
+                                "type": "string"
                             },
                             "enabled": {
                                 "$ref": "#/$defs/boolean_or_jinja_string"

--- a/tests/dbt_project.yml
+++ b/tests/dbt_project.yml
@@ -40,4 +40,4 @@ models:
 
 seeds:
   test:
-    enabled: false
+    +enabled: false

--- a/tests/dbt_project.yml
+++ b/tests/dbt_project.yml
@@ -37,3 +37,8 @@ models:
     # Config indicated by + and applies to all files under models/example/
     example:
       +materialized: view
+
+seeds:
+  test:
+    # Config indicated by + and applies to all files under models/example/
+    +enabled: false

--- a/tests/dbt_project.yml
+++ b/tests/dbt_project.yml
@@ -40,4 +40,4 @@ models:
 
 seeds:
   test:
-    +enabled: false
+    enabled: false

--- a/tests/dbt_project.yml
+++ b/tests/dbt_project.yml
@@ -40,5 +40,4 @@ models:
 
 seeds:
   test:
-    # Config indicated by + and applies to all files under models/example/
     +enabled: false


### PR DESCRIPTION
RIght now, I am getting a syntax error with this block in my `dbt_project.yml`

```yml
seeds:
  test:
    +enabled: false
```

<img width="588" alt="image" src="https://user-images.githubusercontent.com/73915542/218558079-f87b7464-a307-4185-8047-5ac9a052f603.png">


This update should allow the enabled config on seeds to remove this error

Closes #27 