### PR TITLE
allow all snapshot configs

### DIFF
--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -308,7 +308,46 @@
             "title": "Snapshot configs",
             "type": "object",
             "properties": {
+                "+alias": {
+                    "type": "string"
+                },
+                "+check_cols": {
+                    "$ref": "#/$defs/string_or_array_of_strings"
+                },
+                "+enabled": {
+                    "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "+grants": {
+                    "type": "object"
+                },
+                "+persist_docs": {
+                    "$ref": "#/$defs/persist_docs_config"
+                },
+                "+post-hook": {
+                    "$ref": "#/$defs/array_of_strings"
+                },
+                "+pre-hook": {
+                    "$ref": "#/$defs/array_of_strings"
+                },
+                "+quote_columns": {
+                    "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "+strategy": {
+                    "type": "string"
+                },
+                "+tags": {
+                    "$ref": "#/$defs/string_or_array_of_strings"
+                },
+                "+target_database": {
+                    "type": "string"
+                },
                 "+target_schema": {
+                    "type": "string"
+                },
+                "+unique_key": {
+                    "$ref": "#/$defs/string_or_array_of_strings"
+                },
+                "+updated_at": {
                     "type": "string"
                 }
             },

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -6,877 +6,908 @@
         "version"
     ],
     "properties": {
-        "version": {
-            "type": "number",
-            "const": 2
-        },
-        "analyses": {
-            "type": "array",
-            "items": {
+      "version": {
+        "type": "number",
+        "const": 2
+      },
+      "analyses": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "columns": {
+              "type": "array",
+              "items": {
                 "type": "object",
-                "required": [
-                    "name"
-                ],
+                "required": ["name"],
                 "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "columns": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "name"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "description": {
-                                    "type": "string"
-                                },
-                                "data_type": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "config": {
-                        "type": "object",
-                        "properties": {
-                            "tags": {
-                                "$ref": "#/$defs/string_or_array_of_strings"
-                            }
-                        },
-                        "additionalProperties": false
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "docs": {
-                        "type": "object",
-                        "required": [
-                            "show"
-                        ],
-                        "properties": {
-                            "show": {
-                                "type": "boolean"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "exposures": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "required": [
-                    "depends_on",
-                    "name",
-                    "owner",
-                    "type"
-                ],
-                "$comment": "NB: depends_on is not strictly required, but is _expected_ according to the documentation",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "label": {
-                        "type": "string",
-                        "$comment": "Added in dbt Core v1.3"
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": [
-                            "dashboard",
-                            "notebook",
-                            "analysis",
-                            "ml",
-                            "application"
-                        ]
-                    },
-                    "depends_on": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "maturity": {
-                        "type": "string",
-                        "enum": [
-                            "high",
-                            "medium",
-                            "low"
-                        ]
-                    },
-                    "meta": {
-                        "type": "object"
-                    },
-                    "owner": {
-                        "type": "object",
-                        "required": [
-                            "email"
-                        ],
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "email": {
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false
-                    },
-                    "tags": {
-                        "$ref": "#/$defs/string_or_array_of_strings"
-                    },
-                    "url": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "macros": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "required": [
-                    "name"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "arguments": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "name"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "type": {
-                                    "type": "string"
-                                },
-                                "description": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "docs": {
-                        "type": "object",
-                        "properties": {
-                            "show": {
-                                "type": "boolean"
-                            }
-                        }
-                    }
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "data_type": {
+                    "type": "string"
+                  }
                 },
                 "additionalProperties": false
-            }
-        },
-        "metrics": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "required": [
-                    "name",
-                    "type",
-                    "sql",
-                    "timestamp",
-                    "time_grains"
-                ],
-                "if": {
-                    "properties": {
-                        "type": {
-                            "const": "expression"
-                        }
-                    }
-                },
-                "then": {
-                    "required": [
-                        "name",
-                        "type",
-                        "sql",
-                        "timestamp",
-                        "time_grains"
-                    ]
-                },
-                "else": {
-                    "required": [
-                        "name",
-                        "type",
-                        "sql",
-                        "timestamp",
-                        "time_grains",
-                        "model"
-                    ]
-                },
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "dimensions": {
-                        "$ref": "#/$defs/array_of_strings"
-                    },
-                    "filters": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "field",
-                                "operator",
-                                "value"
-                            ],
-                            "properties": {
-                                "field": {
-                                    "type": "string"
-                                },
-                                "operator": {
-                                    "type": "string"
-                                },
-                                "value": {
-                                    "type": "string"
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "label": {
-                        "type": "string"
-                    },
-                    "model": {
-                        "type": "string",
-                        "default": "ref('')"
-                    },
-                    "sql": {
-                        "type": "string"
-                    },
-                    "time_grains": {
-                        "$ref": "#/$defs/array_of_strings"
-                    },
-                    "timestamp": {
-                        "type": "string"
-                    }
-                }
-            }
-        },
-        "models": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "required": [
-                    "name"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "columns": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/$defs/column_properties"
-                        }
-                    },
-                    "config": {
-                        "type": "object",
-                        "properties": {
-                            "grant_access_to": {
-                                "title": "Authorized views",
-                                "type": "array",
-                                "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
-                                "items": {
-                                    "type": "object",
-                                    "required": [
-                                        "database",
-                                        "project"
-                                    ],
-                                    "properties": {
-                                        "database": {
-                                            "type": "string"
-                                        },
-                                        "project": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                }
-                            },
-                            "hours_to_expiration": {
-                                "type": "number",
-                                "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
-                            },
-                            "kms_key_name": {
-                                "type": "string",
-                                "description": "Configuration of the KMS key name, specific to BigQuery adapter.",
-                                "pattern": "projects/[a-zA-Z0-9_-]*/locations/[a-zA-Z0-9_-]*/keyRings/.*/cryptoKeys/.*"
-                            },
-                            "labels": {
-                                "title": "Label configs",
-                                "type": "object",
-                                "description": "Configuration specific to BigQuery adapter used to add labels and tags to tables/views created by dbt.",
-                                "patternProperties": {
-                                    "^[a-z][a-z0-9]{0,63}$": {
-                                        "type": "string",
-                                        "pattern": "^[a-z0-9_-]{0,64}$"
-                                    }
-                                },
-                                "additionalProperties": false
-                            },
-                            "materialized": {
-                                "type": "string"
-                            },
-                            "sql_header": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "docs": {
-                        "type": "object",
-                        "properties": {
-                            "show": {
-                                "type": "boolean"
-                            }
-                        }
-                    },
-                    "meta": {
-                        "type": "object"
-                    },
-                    "tests": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/$defs/tests"
-                        }
-                    }
-                },
-                "additionalProperties": false
-            }
-        },
-        "seeds": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "required": [
-                    "name"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "columns": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/$defs/column_properties"
-                        }
-                    },
-                    "config": {
-                        "type": "object",
-                        "properties": {
-                            "column_types": {
-                                "type": "object"
-                            },
-                            "copy_grants": {
-                                "$ref": "#/$defs/boolean_or_jinja_string"
-                            },
-                            "database": {
-                                "type": "string"
-                            },
-                            "enabled": {
-                                "$ref": "#/$defs/boolean_or_jinja_string"
-                            },
-                            "quote_columns": {
-                                "$ref": "#/$defs/boolean_or_jinja_string"
-                            },
-                            "schema": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "docs": {
-                        "type": "object",
-                        "properties": {
-                            "show": {
-                                "type": "boolean"
-                            }
-                        }
-                    },
-                    "tests": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/$defs/tests"
-                        }
-                    }
-                },
-                "additionalProperties": false
-            }
-        },
-        "sources": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "required": [
-                    "name"
-                ],
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "description": "How you will identify the schema in {{ source() }} calls. Unless `schema` is also set, this will be the name of the schema in the database."
-                    },
-                    "config": {
-                        "type": "object"
-                    },
-                    "database": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "freshness": {
-                        "$ref": "#/$defs/freshness_definition"
-                    },
-                    "loaded_at_field": {
-                        "type": "string"
-                    },
-                    "loader": {
-                        "type": "string"
-                    },
-                    "meta": {
-                        "type": "object"
-                    },
-                    "overrides": {
-                        "title": "Package to Override",
-                        "type": "string",
-                        "description": "The name of another package installed in your project. If that package has a source with the same name as this one, its properties will be applied on top of the base properties of the overridden source. https://docs.getdbt.com/reference/resource-properties/overrides"
-                    },
-                    "quoting": {
-                        "type": "object",
-                        "properties": {
-                            "database": {
-                                "$ref": "#/$defs/boolean_or_jinja_string"
-                            },
-                            "identifier": {
-                                "$ref": "#/$defs/boolean_or_jinja_string"
-                            },
-                            "schema": {
-                                "$ref": "#/$defs/boolean_or_jinja_string"
-                            }
-                        },
-                        "additionalProperties": false
-                    },
-                    "schema": {
-                        "type": "string",
-                        "description": "The schema name as stored in the database. Only needed if you want to use a different `name` than what exists in the database (otherwise `name` is used by default)"
-                    },
-                    "tables": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": [
-                                "name"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "title": "Name",
-                                    "type": "string",
-                                    "description": "How you will identify the table in {{ source() }} calls. Unless `identifier` is also set, this will be the name of the table in the database."
-                                },
-                                "columns": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/$defs/column_properties"
-                                    }
-                                },
-                                "description": {
-                                    "type": "string"
-                                },
-                                "external": {
-                                    "type": "object"
-                                },
-                                "freshness": {
-                                    "$ref": "#/$defs/freshness_definition"
-                                },
-                                "identifier": {
-                                    "title": "Identifier",
-                                    "type": "string",
-                                    "description": "The table name as stored in the database. Only needed if you want to give the source a different name than what exists in the database (otherwise `name` is used by default)"
-                                },
-                                "loaded_at_field": {
-                                    "type": "string",
-                                    "description": "Which column to check during data freshness tests. Only needed if the table has a different loaded_at_field to the one defined on the source overall."
-                                },
-                                "loader": {
-                                    "type": "string"
-                                },
-                                "meta": {
-                                    "type": "object"
-                                },
-                                "quoting": {
-                                    "type": "object",
-                                    "properties": {
-                                        "database": {
-                                            "$ref": "#/$defs/boolean_or_jinja_string"
-                                        },
-                                        "identifier": {
-                                            "$ref": "#/$defs/boolean_or_jinja_string"
-                                        },
-                                        "schema": {
-                                            "$ref": "#/$defs/boolean_or_jinja_string"
-                                        }
-                                    },
-                                    "additionalProperties": false
-                                },
-                                "tags": {
-                                    "$ref": "#/$defs/string_or_array_of_strings"
-                                },
-                                "tests": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/$defs/tests"
-                                    }
-                                }
-                            },
-                            "additionalProperties": false
-                        }
-                    },
-                    "tags": {
-                        "$ref": "#/$defs/string_or_array_of_strings"
-                    },
-                    "tests": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/$defs/tests"
-                        }
-                    }
-                }
-            }
-        }
-    },
-    "additionalProperties": false,
-    "$defs": {
-        "array_of_strings": {
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
-        },
-        "boolean_or_jinja_string": {
-            "oneOf": [
-                {
-                    "$ref": "#/$defs/jinja_string"
-                },
-                {
-                    "type": "boolean"
-                }
-            ],
-            "additionalProperties": false
-        },
-        "column_properties": {
-            "type": "object",
-            "required": [
-                "name"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "data_type": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "meta": {
-                    "type": "object"
-                },
-                "policy_tags": {
-                    "title": "Policy tags",
-                    "type": "array",
-                    "description": "Configurations, specific to BigQuery adapter, used to set policy tags on specific columns, enabling column-level security. Only relevant when `persist_docs.columns` is true.",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "quote": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
-                },
-                "tests": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/$defs/tests"
-                    }
-                },
+              }
+            },
+            "config": {
+              "type": "object",
+              "properties": {
                 "tags": {
-                    "$ref": "#/$defs/string_or_array_of_strings"
+                  "$ref": "#/$defs/string_or_array_of_strings"
                 }
+              },
+              "additionalProperties": false
             },
-            "additionalProperties": false
-        },
-        "freshness_definition": {
-            "default": {
-                "warn_after": {
-                    "count": 1,
-                    "period": "day"
+            "description": {
+              "type": "string"
+            },
+            "docs": {
+              "type": "object",
+              "required": ["show"],
+              "properties": {
+                "show": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "exposures": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["depends_on", "name", "owner", "type"],
+          "$comment": "NB: depends_on is not strictly required, but is _expected_ according to the documentation",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string",
+              "$comment": "Added in dbt Core v1.3"
+            },
+            "type": {
+              "type": "string",
+              "enum": ["dashboard", "notebook", "analysis", "ml", "application"]
+            },
+            "depends_on": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": {
+              "type": "string"
+            },
+            "maturity": {
+              "type": "string",
+              "enum": ["high", "medium", "low"]
+            },
+            "meta": {
+              "type": "object"
+            },
+            "owner": {
+              "type": "object",
+              "required": ["email"],
+              "properties": {
+                "name": {
+                  "type": "string"
                 },
-                "error_after": {
-                    "count": 2,
-                    "period": "day"
+                "email": {
+                  "type": "string"
                 }
+              },
+              "additionalProperties": false
             },
-            "oneOf": [
-                {
+            "tags": {
+              "$ref": "#/$defs/string_or_array_of_strings"
+            },
+            "url": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "macros": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "arguments": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "description": {
+              "type": "string"
+            },
+            "docs": {
+              "type": "object",
+              "properties": {
+                "show": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "metrics": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name", "type", "sql", "timestamp", "time_grains"],
+          "if": {
+            "properties": {
+              "type": {
+                "const": "expression"
+              }
+            }
+          },
+          "then": {
+            "required": ["name", "type", "sql", "timestamp", "time_grains"]
+          },
+          "else": {
+            "required": [
+              "name",
+              "type",
+              "sql",
+              "timestamp",
+              "time_grains",
+              "model"
+            ]
+          },
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "dimensions": {
+              "$ref": "#/$defs/array_of_strings"
+            },
+            "filters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["field", "operator", "value"],
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  },
+                  "operator": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "label": {
+              "type": "string"
+            },
+            "model": {
+              "type": "string",
+              "default": "ref('')"
+            },
+            "sql": {
+              "type": "string"
+            },
+            "time_grains": {
+              "$ref": "#/$defs/array_of_strings"
+            },
+            "timestamp": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "models": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "columns": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/column_properties"
+              }
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "grant_access_to": {
+                  "title": "Authorized views",
+                  "type": "array",
+                  "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
+                  "items": {
                     "type": "object",
+                    "required": ["database", "project"],
                     "properties": {
-                        "error_after": {
-                            "$ref": "#/$defs/freshness_rules"
-                        },
-                        "filter": {
-                            "type": "string"
-                        },
-                        "warn_after": {
-                            "$ref": "#/$defs/freshness_rules"
-                        }
+                      "database": {
+                        "type": "string"
+                      },
+                      "project": {
+                        "type": "string"
+                      }
                     },
                     "additionalProperties": false
+                  }
                 },
-                {
-                    "const": null
-                }
-            ]
-        },
-        "freshness_rules": {
-            "type": "object",
-            "required": [
-                "count",
-                "period"
-            ],
-            "properties": {
-                "count": {
-                    "$ref": "#/$defs/number_or_jinja_string"
+                "hours_to_expiration": {
+                  "type": "number",
+                  "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
                 },
-                "period": {
-                    "type": "string",
-                    "enum": [
-                        "minute",
-                        "hour",
-                        "day"
-                    ]
+                "kms_key_name": {
+                  "type": "string",
+                  "description": "Configuration of the KMS key name, specific to BigQuery adapter.",
+                  "pattern": "projects/[a-zA-Z0-9_-]*/locations/[a-zA-Z0-9_-]*/keyRings/.*/cryptoKeys/.*"
+                },
+                "labels": {
+                  "title": "Label configs",
+                  "type": "object",
+                  "description": "Configuration specific to BigQuery adapter used to add labels and tags to tables/views created by dbt.",
+                  "patternProperties": {
+                    "^[a-z][a-z0-9]{0,63}$": {
+                      "type": "string",
+                      "pattern": "^[a-z0-9_-]{0,64}$"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "materialized": {
+                  "type": "string"
+                },
+                "sql_header": {
+                  "type": "string"
                 }
+              }
             },
-            "additionalProperties": false
-        },
-        "jinja_string": {
-            "type": "string",
-            "pattern": "\\{\\{.*\\}\\}"
-        },
-        "number_or_jinja_string": {
-            "oneOf": [
-                {
-                    "$ref": "#/$defs/jinja_string"
-                },
-                {
-                    "type": "number"
+            "description": {
+              "type": "string"
+            },
+            "docs": {
+              "type": "object",
+              "properties": {
+                "show": {
+                  "type": "boolean"
                 }
-            ],
-            "additionalProperties": false
-        },
-        "string_or_array_of_strings": {
-            "oneOf": [
-                {
-                    "type": "string"
+              }
+            },
+            "meta": {
+              "type": "object"
+            },
+            "tests": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/tests"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "seeds": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "columns": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/column_properties"
+              }
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "column_types": {
+                  "type": "object"
                 },
-                {
-                    "$ref": "#/$defs/array_of_strings"
-                }
-            ]
-        },
-        "test_configs": {
-            "title": "Test configs",
-            "type": "object",
-            "description": "Configurations set here will override configs set in dbt_project.yml.",
-            "properties": {
-                "alias": {
-                    "type": "string",
-                    "description": "Only relevant when `store_failures` is true"
+                "copy_grants": {
+                  "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "database": {
-                    "type": "string",
-                    "description": "Only relevant when `store_failures` is true"
+                  "type": "string"
+                },
+                "enabled": {
+                  "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "quote_columns": {
+                  "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": {
+              "type": "string"
+            },
+            "docs": {
+              "type": "object",
+              "properties": {
+                "show": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "tests": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/tests"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "snapshots": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "columns": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/column_properties"
+              }
+            },
+            "config": {
+              "type": "object",
+              "properties": {
+                "alias": {
+                    "type": "string"
+                },
+                "check_cols": {
+                    "$ref": "#/$defs/string_or_array_of_strings"
                 },
                 "enabled": {
                     "$ref": "#/$defs/boolean_or_jinja_string"
                 },
-                "error_if": {
-                    "type": "string"
+                "grants": {
+                    "type": "object"
                 },
-                "fail_calc": {
-                    "type": "string"
+                "persist_docs": {
+                    "$ref": "#/$defs/persist_docs_config"
                 },
-                "limit": {
-                    "type": "number"
+                "post-hook": {
+                    "$ref": "#/$defs/array_of_strings"
                 },
-                "schema": {
-                    "type": "string",
-                    "description": "Only relevant when `store_failures` is true"
+                "pre-hook": {
+                    "$ref": "#/$defs/array_of_strings"
                 },
-                "severity": {
-                    "type": "string",
-                    "enum": [
-                        "warn",
-                        "error"
-                    ]
-                },
-                "store_failures": {
+                "quote_columns": {
                     "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "strategy": {
+                    "type": "string"
                 },
                 "tags": {
                     "$ref": "#/$defs/string_or_array_of_strings"
                 },
-                "warn_if": {
+                "target_database": {
+                    "type": "string"
+                },
+                "target_schema": {
+                    "type": "string"
+                },
+                "unique_key": {
+                    "$ref": "#/$defs/string_or_array_of_strings"
+                },
+                "updated_at": {
                     "type": "string"
                 }
+              }
+            },
+            "description": {
+              "type": "string"
+            },
+            "docs": {
+              "type": "object",
+              "properties": {
+                "show": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "meta": {
+              "type": "object"
+            },
+            "tests": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/tests"
+              }
             }
-        },
-        "tests": {
-            "anyOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "title": "Relationships Test",
-                    "type": "object",
-                    "properties": {
-                        "relationships": {
-                            "type": "object",
-                            "required": [
-                                "to",
-                                "field"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "config": {
-                                    "$ref": "#/$defs/test_configs"
-                                },
-                                "field": {
-                                    "title": "Relationships: Field",
-                                    "type": "string",
-                                    "default": "<FOREIGN_KEY_COLUMN>",
-                                    "description": "The foreign key column"
-                                },
-                                "to": {
-                                    "type": "string",
-                                    "default": "ref('')",
-                                    "examples": [
-                                        "ref('parent_model')",
-                                        "source('parent_schema', 'parent_table')"
-                                    ]
-                                },
-                                "where": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "title": "Accepted Values Test",
-                    "type": "object",
-                    "properties": {
-                        "accepted_values": {
-                            "type": "object",
-                            "required": [
-                                "values"
-                            ],
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "config": {
-                                    "$ref": "#/$defs/test_configs"
-                                },
-                                "quote": {
-                                    "type": "boolean"
-                                },
-                                "values": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "where": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "title": "Not Null Test",
-                    "type": "object",
-                    "properties": {
-                        "not_null": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "config": {
-                                    "$ref": "#/$defs/test_configs"
-                                },
-                                "where": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "title": "Unique Test",
-                    "type": "object",
-                    "properties": {
-                        "unique": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "config": {
-                                    "$ref": "#/$defs/test_configs"
-                                },
-                                "where": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
+          },
+          "additionalProperties": false
         }
+      },
+      "sources": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "How you will identify the schema in {{ source() }} calls. Unless `schema` is also set, this will be the name of the schema in the database."
+            },
+            "config": {
+              "type": "object"
+            },
+            "database": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "freshness": {
+              "$ref": "#/$defs/freshness_definition"
+            },
+            "loaded_at_field": {
+              "type": "string"
+            },
+            "loader": {
+              "type": "string"
+            },
+            "meta": {
+              "type": "object"
+            },
+            "overrides": {
+              "title": "Package to Override",
+              "type": "string",
+              "description": "The name of another package installed in your project. If that package has a source with the same name as this one, its properties will be applied on top of the base properties of the overridden source. https://docs.getdbt.com/reference/resource-properties/overrides"
+            },
+            "quoting": {
+              "type": "object",
+              "properties": {
+                "database": {
+                  "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "identifier": {
+                  "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "schema": {
+                  "$ref": "#/$defs/boolean_or_jinja_string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "schema": {
+              "type": "string",
+              "description": "The schema name as stored in the database. Only needed if you want to use a different `name` than what exists in the database (otherwise `name` is used by default)"
+            },
+            "tables": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {
+                    "title": "Name",
+                    "type": "string",
+                    "description": "How you will identify the table in {{ source() }} calls. Unless `identifier` is also set, this will be the name of the table in the database."
+                  },
+                  "columns": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/column_properties"
+                    }
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "external": {
+                    "type": "object"
+                  },
+                  "freshness": {
+                    "$ref": "#/$defs/freshness_definition"
+                  },
+                  "identifier": {
+                    "title": "Identifier",
+                    "type": "string",
+                    "description": "The table name as stored in the database. Only needed if you want to give the source a different name than what exists in the database (otherwise `name` is used by default)"
+                  },
+                  "loaded_at_field": {
+                    "type": "string",
+                    "description": "Which column to check during data freshness tests. Only needed if the table has a different loaded_at_field to the one defined on the source overall."
+                  },
+                  "loader": {
+                    "type": "string"
+                  },
+                  "meta": {
+                    "type": "object"
+                  },
+                  "quoting": {
+                    "type": "object",
+                    "properties": {
+                      "database": {
+                        "$ref": "#/$defs/boolean_or_jinja_string"
+                      },
+                      "identifier": {
+                        "$ref": "#/$defs/boolean_or_jinja_string"
+                      },
+                      "schema": {
+                        "$ref": "#/$defs/boolean_or_jinja_string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "tags": {
+                    "$ref": "#/$defs/string_or_array_of_strings"
+                  },
+                  "tests": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/tests"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "tags": {
+              "$ref": "#/$defs/string_or_array_of_strings"
+            },
+            "tests": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/tests"
+              }
+            }
+          }
+        }
+      }
+    },
+    "additionalProperties": false,
+    "$defs": {
+      "array_of_strings": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "boolean_or_jinja_string": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/jinja_string"
+          },
+          {
+            "type": "boolean"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "column_properties": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "data_type": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "meta": {
+            "type": "object"
+          },
+          "policy_tags": {
+            "title": "Policy tags",
+            "type": "array",
+            "description": "Configurations, specific to BigQuery adapter, used to set policy tags on specific columns, enabling column-level security. Only relevant when `persist_docs.columns` is true.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "quote": {
+            "$ref": "#/$defs/boolean_or_jinja_string"
+          },
+          "tests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/tests"
+            }
+          },
+          "tags": {
+            "$ref": "#/$defs/string_or_array_of_strings"
+          }
+        },
+        "additionalProperties": false
+      },
+      "freshness_definition": {
+        "default": {
+          "warn_after": {
+            "count": 1,
+            "period": "day"
+          },
+          "error_after": {
+            "count": 2,
+            "period": "day"
+          }
+        },
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "error_after": {
+                "$ref": "#/$defs/freshness_rules"
+              },
+              "filter": {
+                "type": "string"
+              },
+              "warn_after": {
+                "$ref": "#/$defs/freshness_rules"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "const": null
+          }
+        ]
+      },
+      "freshness_rules": {
+        "type": "object",
+        "required": ["count", "period"],
+        "properties": {
+          "count": {
+            "$ref": "#/$defs/number_or_jinja_string"
+          },
+          "period": {
+            "type": "string",
+            "enum": ["minute", "hour", "day"]
+          }
+        },
+        "additionalProperties": false
+      },
+      "jinja_string": {
+        "type": "string",
+        "pattern": "\\{\\{.*\\}\\}"
+      },
+      "number_or_jinja_string": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/jinja_string"
+          },
+          {
+            "type": "number"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "persist_docs_config": {
+        "title": "Persist docs config",
+        "type": "object",
+        "description": "Configurations for the persistence of the dbt documentation.",
+        "properties": {
+          "columns": {
+            "$ref": "#/$defs/boolean_or_jinja_string",
+            "default": true
+          },
+          "relation": {
+            "$ref": "#/$defs/boolean_or_jinja_string",
+            "default": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "string_or_array_of_strings": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/$defs/array_of_strings"
+          }
+        ]
+      },
+      "test_configs": {
+        "title": "Test configs",
+        "type": "object",
+        "description": "Configurations set here will override configs set in dbt_project.yml.",
+        "properties": {
+          "alias": {
+            "type": "string",
+            "description": "Only relevant when `store_failures` is true"
+          },
+          "database": {
+            "type": "string",
+            "description": "Only relevant when `store_failures` is true"
+          },
+          "enabled": {
+            "$ref": "#/$defs/boolean_or_jinja_string"
+          },
+          "error_if": {
+            "type": "string"
+          },
+          "fail_calc": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "schema": {
+            "type": "string",
+            "description": "Only relevant when `store_failures` is true"
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["warn", "error"]
+          },
+          "store_failures": {
+            "$ref": "#/$defs/boolean_or_jinja_string"
+          },
+          "tags": {
+            "$ref": "#/$defs/string_or_array_of_strings"
+          },
+          "warn_if": {
+            "type": "string"
+          }
+        }
+      },
+      "tests": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "title": "Relationships Test",
+            "type": "object",
+            "properties": {
+              "relationships": {
+                "type": "object",
+                "required": ["to", "field"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "$ref": "#/$defs/test_configs"
+                  },
+                  "field": {
+                    "title": "Relationships: Field",
+                    "type": "string",
+                    "default": "<FOREIGN_KEY_COLUMN>",
+                    "description": "The foreign key column"
+                  },
+                  "to": {
+                    "type": "string",
+                    "default": "ref('')",
+                    "examples": [
+                      "ref('parent_model')",
+                      "source('parent_schema', 'parent_table')"
+                    ]
+                  },
+                  "where": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "title": "Accepted Values Test",
+            "type": "object",
+            "properties": {
+              "accepted_values": {
+                "type": "object",
+                "required": ["values"],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "$ref": "#/$defs/test_configs"
+                  },
+                  "quote": {
+                    "type": "boolean"
+                  },
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "where": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "title": "Not Null Test",
+            "type": "object",
+            "properties": {
+              "not_null": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "$ref": "#/$defs/test_configs"
+                  },
+                  "where": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "title": "Unique Test",
+            "type": "object",
+            "properties": {
+              "unique": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "$ref": "#/$defs/test_configs"
+                  },
+                  "where": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
     }
 }

--- a/tests/dbt_project.yml
+++ b/tests/dbt_project.yml
@@ -41,3 +41,10 @@ models:
 seeds:
   test:
     +enabled: false
+
+snapshots:
+  tests: 
+    +target_schema: schema 
+    +target_database: database 
+    +grants:
+      select: ['role']

--- a/tests/schema.yml
+++ b/tests/schema.yml
@@ -20,3 +20,11 @@ models:
         tests:
           - unique
           - not_null
+
+
+snapshots:
+  - name: snapshot_name
+    description: slowly changing dimension
+    columns:
+      - name: id 
+        description: cool column, eh?


### PR DESCRIPTION
closes #15 

This adds all available configs from [this page](https://docs.getdbt.com/reference/snapshot-configs) to snapshot configs in the project json, and extends them into a new entry in `dbt_yml_files`

it looks like I may have reformatted the entire JSON for the dbt_yml_files -- i can try to revert if we want