### PR TITLE
Model contract configs

### DIFF
--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -163,6 +163,18 @@
                 "type": "string"
             }
         },
+        "contract": {
+            "type": "object",
+            "required": [
+                "enforced"
+            ],
+            "properties": {
+                "enforced": {
+                  "$ref": "#/$defs/boolean_or_jinja_string",
+                  "default": "true"
+                }
+            }
+        },
         "empty_directory": {
             "type": "null"
         },
@@ -255,7 +267,7 @@
                     "default": false
                 },
                 "+contract": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/contract"
                 },
                 "+database": {
                     "$ref": "#/$defs/database"
@@ -313,7 +325,7 @@
                     "default": false
                 },
                 "contract": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/contract"
                 },
                 "database": {
                     "$ref": "#/$defs/database"

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -224,6 +224,9 @@
                     "$ref": "#/$defs/boolean_or_jinja_string",
                     "default": false
                 },
+                "+contract": {
+                    "$ref": "#/$defs/boolean_or_jinja_string"
+                },
                 "+database": {
                     "$ref": "#/$defs/database"
                 },
@@ -275,6 +278,9 @@
                 "bind": {
                     "$ref": "#/$defs/boolean_or_jinja_string",
                     "default": false
+                },
+                "contract": {
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "database": {
                     "$ref": "#/$defs/database"

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -163,7 +163,7 @@
             }
         },
         "empty_directory": {
-          "type": "null"
+            "type": "null"
         },
         "boolean_or_jinja_string": {
             "oneOf": [
@@ -221,82 +221,110 @@
             "description": "Configurations set in the dbt_project.yml file will apply to all models that don't have a more specific configuration set.",
             "properties": {
                 "+bind": {
-                    "$ref": "#/$defs/boolean_or_jinja_string",
-                    "default": false
+                    "$ref": "#/$defs/bind"
                 },
                 "+database": {
-                    "type": "string"
+                    "$ref": "#/$defs/database"
                 },
                 "+docs": {
-                    "$ref": "#/$defs/docs_config"
+                    "$ref": "#/$defs/docs"
                 },
                 "+enabled": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/enabled"
                 },
                 "+grant_access_to": {
-                    "title": "Authorized views",
-                    "type": "array",
-                    "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "database": {
-                                "type": "string"
-                            },
-                            "project": {
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false
-                    }
+                    "$ref": "#/$defs/grant_access_to"
                 },
                 "+hours_to_expiration": {
-                    "type": "number",
-                    "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
+                    "$ref": "#/$defs/hours_to_expiration"
                 },
                 "+incremental_strategy": {
-                    "type": "string"
+                    "$ref": "#/$defs/incremental_strategy"
                 },
                 "+kms_key_name": {
-                    "type": "string",
-                    "description": "Configuration, specific to BigQuery adapter, of the KMS key name used for data encryption."
+                    "$ref": "#/$defs/kms_key_name"
                 },
                 "+labels": {
-                    "$ref": "#/$defs/label_configs"
+                    "$ref": "#/$defs/labels"
                 },
                 "+materialized": {
-                    "type": "string"
+                    "$ref": "#/$defs/materialized"
                 },
                 "+on_schema_change": {
-                    "type": "string",
-                    "enum": [
-                        "append_new_columns",
-                        "fail",
-                        "ignore",
-                        "sync_all_columns"
-                    ]
+                    "$ref": "#/$defs/on_schema_change"
                 },
                 "+persist_docs": {
-                    "$ref": "#/$defs/persist_docs_config"
+                    "$ref": "#/$defs/persist_docs"
                 },
                 "+post-hook": {
-                    "$ref": "#/$defs/array_of_strings"
+                    "$ref": "#/$defs/post-hook"
                 },
                 "+pre-hook": {
-                    "$ref": "#/$defs/array_of_strings"
+                    "$ref": "#/$defs/pre-hook"
                 },
                 "+schema": {
-                    "type": "string"
+                    "$ref": "#/$defs/schema"
                 },
                 "+sql_header": {
-                    "type": "string"
+                    "$ref": "#/$defs/sql_header"
                 },
                 "+tags": {
-                    "$ref": "#/$defs/string_or_array_of_strings"
+                    "$ref": "#/$defs/tags"
+                },
+                "bind": {
+                    "$ref": "#/$defs/bind"
+                },
+                "database": {
+                    "$ref": "#/$defs/database"
+                },
+                "docs": {
+                    "$ref": "#/$defs/docs"
+                },
+                "enabled": {
+                    "$ref": "#/$defs/enabled"
+                },
+                "grant_access_to": {
+                    "$ref": "#/$defs/grant_access_to"
+                },
+                "hours_to_expiration": {
+                    "$ref": "#/$defs/hours_to_expiration"
+                },
+                "incremental_strategy": {
+                    "$ref": "#/$defs/incremental_strategy"
+                },
+                "kms_key_name": {
+                    "$ref": "#/$defs/kms_key_name"
+                },
+                "labels": {
+                    "$ref": "#/$defs/labels"
+                },
+                "materialized": {
+                    "$ref": "#/$defs/materialized"
+                },
+                "on_schema_change": {
+                    "$ref": "#/$defs/on_schema_change"
+                },
+                "persist_docs": {
+                    "$ref": "#/$defs/persist_docs"
+                },
+                "post-hook": {
+                    "$ref": "#/$defs/post-hook"
+                },
+                "pre-hook": {
+                    "$ref": "#/$defs/pre-hook"
+                },
+                "schema": {
+                    "$ref": "#/$defs/schema"
+                },
+                "sql_header": {
+                    "$ref": "#/$defs/sql_header"
+                },
+                "tags": {
+                    "$ref": "#/$defs/tags"
                 }
             },
             "additionalProperties": {
-                "oneOf" : [
+                "oneOf": [
                     {
                         "$ref": "#/$defs/model_configs"
                     },
@@ -327,40 +355,62 @@
             "type": "object",
             "properties": {
                 "+copy_grants": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/copy_grants"
                 },
                 "+database": {
-                    "type": "string"
+                    "$ref": "#/$defs/database"
                 },
                 "+enabled": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/enabled"
                 },
                 "+persist_docs": {
-                    "$ref": "#/$defs/persist_docs_config"
+                    "$ref": "#/$defs/persist_docs"
                 },
                 "+quote_columns": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/quote_columns"
                 },
                 "+schema": {
-                    "type": "string"
+                    "$ref": "#/$defs/schema"
                 },
                 "+tags": {
-                    "$ref": "#/$defs/string_or_array_of_strings"
+                    "$ref": "#/$defs/tags"
                 },
                 "+column_types": {
-                    "type": "object",
-                    "patternProperties": {
-                        "": {
-                            "type": "string"
-                        }
-                    }
+                    "$ref": "#/$defs/column_types"
                 },
                 "+full_refresh": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/full_refresh"
+                },
+                "copy_grants": {
+                    "$ref": "#/$defs/copy_grants"
+                },
+                "database": {
+                    "$ref": "#/$defs/database"
+                },
+                "enabled": {
+                    "$ref": "#/$defs/enabled"
+                },
+                "persist_docs": {
+                    "$ref": "#/$defs/persist_docs"
+                },
+                "quote_columns": {
+                    "$ref": "#/$defs/quote_columns"
+                },
+                "schema": {
+                    "$ref": "#/$defs/schema"
+                },
+                "tags": {
+                    "$ref": "#/$defs/tags"
+                },
+                "column_types": {
+                    "$ref": "#/$defs/column_types"
+                },
+                "full_refresh": {
+                    "$ref": "#/$defs/full_refresh"
                 }
             },
             "additionalProperties": {
-                "oneOf" : [
+                "oneOf": [
                     {
                         "$ref": "#/$defs/seed_configs"
                     },
@@ -375,50 +425,92 @@
             "type": "object",
             "properties": {
                 "+alias": {
-                    "type": "string"
+                    "$ref": "#/$defs/alias"
                 },
                 "+check_cols": {
-                    "$ref": "#/$defs/string_or_array_of_strings"
+                    "$ref": "#/$defs/check_cols"
                 },
                 "+enabled": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/enabled"
                 },
                 "+grants": {
-                    "type": "object"
+                    "$ref": "#/$defs/grants"
                 },
                 "+persist_docs": {
-                    "$ref": "#/$defs/persist_docs_config"
+                    "$ref": "#/$defs/persist_docs"
                 },
                 "+post-hook": {
-                    "$ref": "#/$defs/array_of_strings"
+                    "$ref": "#/$defs/post-hook"
                 },
                 "+pre-hook": {
-                    "$ref": "#/$defs/array_of_strings"
+                    "$ref": "#/$defs/pre-hook"
                 },
                 "+quote_columns": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/quote_columns"
                 },
                 "+strategy": {
-                    "type": "string"
+                    "$ref": "#/$defs/strategy"
                 },
                 "+tags": {
-                    "$ref": "#/$defs/string_or_array_of_strings"
+                    "$ref": "#/$defs/tags"
                 },
                 "+target_database": {
-                    "type": "string"
+                    "$ref": "#/$defs/target_database"
                 },
                 "+target_schema": {
-                    "type": "string"
+                    "$ref": "#/$defs/target_schema"
                 },
                 "+unique_key": {
-                    "$ref": "#/$defs/string_or_array_of_strings"
+                    "$ref": "#/$defs/unique_key"
                 },
                 "+updated_at": {
-                    "type": "string"
+                    "$ref": "#/$defs/updated_at"
+                },
+                "alias": {
+                    "$ref": "#/$defs/alias"
+                },
+                "check_cols": {
+                    "$ref": "#/$defs/check_cols"
+                },
+                "enabled": {
+                    "$ref": "#/$defs/enabled"
+                },
+                "grants": {
+                    "$ref": "#/$defs/grants"
+                },
+                "persist_docs": {
+                    "$ref": "#/$defs/persist_docs"
+                },
+                "post-hook": {
+                    "$ref": "#/$defs/post-hook"
+                },
+                "pre-hook": {
+                    "$ref": "#/$defs/pre-hook"
+                },
+                "quote_columns": {
+                    "$ref": "#/$defs/quote_columns"
+                },
+                "strategy": {
+                    "$ref": "#/$defs/strategy"
+                },
+                "tags": {
+                    "$ref": "#/$defs/tags"
+                },
+                "target_database": {
+                    "$ref": "#/$defs/target_database"
+                },
+                "target_schema": {
+                    "$ref": "#/$defs/target_schema"
+                },
+                "unique_key": {
+                    "$ref": "#/$defs/unique_key"
+                },
+                "updated_at": {
+                    "$ref": "#/$defs/updated_at"
                 }
             },
             "additionalProperties": {
-                "oneOf" : [
+                "oneOf": [
                     {
                         "$ref": "#/$defs/snapshot_configs"
                     },
@@ -433,14 +525,20 @@
             "type": "object",
             "properties": {
                 "+enabled": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/enabled"
                 },
                 "+tags": {
-                    "$ref": "#/$defs/string_or_array_of_strings"
+                    "$ref": "#/$defs/tags"
+                },
+                "enabled": {
+                    "$ref": "#/$defs/enabled"
+                },
+                "tags": {
+                    "$ref": "#/$defs/tags"
                 }
             },
             "additionalProperties": {
-                "oneOf" : [
+                "oneOf": [
                     {
                         "$ref": "#/$defs/source_configs"
                     },
@@ -466,48 +564,74 @@
             "description": "Configurations set in the dbt_project.yml file will apply to all tests that don't have a more specific configuration set.",
             "properties": {
                 "+alias": {
-                    "type": "string",
-                    "description": "Only relevant when `store_failures` is true"
+                    "$ref": "#/$defs/alias"
                 },
                 "+database": {
-                    "type": "string",
-                    "description": "Only relevant when `store_failures` is true"
+                    "$ref": "#/$defs/database"
                 },
                 "+enabled": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/enabled"
                 },
                 "+error_if": {
-                    "type": "string"
+                    "$ref": "#/$defs/error_if"
                 },
                 "+fail_calc": {
-                    "type": "string"
+                    "$ref": "#/$defs/fail_calc"
                 },
                 "+limit": {
-                    "type": "number"
+                    "$ref": "#/$defs/limit"
                 },
                 "+schema": {
-                    "type": "string",
-                    "description": "Only relevant when `store_failures` is true"
+                    "$ref": "#/$defs/schema"
                 },
                 "+severity": {
-                    "type": "string",
-                    "enum": [
-                        "warn",
-                        "error"
-                    ]
+                    "$ref": "#/$defs/severity"
                 },
                 "+store_failures": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
+                    "$ref": "#/$defs/store_failures"
                 },
                 "+tags": {
-                    "$ref": "#/$defs/string_or_array_of_strings"
+                    "$ref": "#/$defs/tags"
                 },
                 "+warn_if": {
-                    "type": "string"
+                    "$ref": "#/$defs/warn_if"
+                },
+                "alias": {
+                    "$ref": "#/$defs/alias"
+                },
+                "database": {
+                    "$ref": "#/$defs/database"
+                },
+                "enabled": {
+                    "$ref": "#/$defs/enabled"
+                },
+                "error_if": {
+                    "$ref": "#/$defs/error_if"
+                },
+                "fail_calc": {
+                    "$ref": "#/$defs/fail_calc"
+                },
+                "limit": {
+                    "$ref": "#/$defs/limit"
+                },
+                "schema": {
+                    "$ref": "#/$defs/schema"
+                },
+                "severity": {
+                    "$ref": "#/$defs/severity"
+                },
+                "store_failures": {
+                    "$ref": "#/$defs/store_failures"
+                },
+                "tags": {
+                    "$ref": "#/$defs/tags"
+                },
+                "warn_if": {
+                    "$ref": "#/$defs/warn_if"
                 }
             },
             "additionalProperties": {
-                "oneOf" : [
+                "oneOf": [
                     {
                         "$ref": "#/$defs/test_configs"
                     },
@@ -516,6 +640,143 @@
                     }
                 ]
             }
+        },
+        "bind": {
+            "$ref": "#/$defs/boolean_or_jinja_string",
+            "default": false
+        },
+        "database": {
+            "type": "string"
+        },
+        "docs": {
+            "$ref": "#/$defs/docs_config"
+        },
+        "enabled": {
+            "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "grant_access_to": {
+            "title": "Authorized views",
+            "type": "array",
+            "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "database": {
+                        "type": "string"
+                    },
+                    "project": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "hours_to_expiration": {
+            "type": "number",
+            "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
+        },
+        "incremental_strategy": {
+            "type": "string"
+        },
+        "kms_key_name": {
+            "type": "string",
+            "description": "Configuration, specific to BigQuery adapter, of the KMS key name used for data encryption."
+        },
+        "labels": {
+            "$ref": "#/$defs/label_configs"
+        },
+        "materialized": {
+            "type": "string"
+        },
+        "on_schema_change": {
+            "type": "string",
+            "enum": [
+                "append_new_columns",
+                "fail",
+                "ignore",
+                "sync_all_columns"
+            ]
+        },
+        "persist_docs": {
+            "$ref": "#/$defs/persist_docs_config"
+        },
+        "post-hook": {
+            "$ref": "#/$defs/array_of_strings"
+        },
+        "pre-hook": {
+            "$ref": "#/$defs/array_of_strings"
+        },
+        "schema": {
+            "type": "string"
+        },
+        "sql_header": {
+            "type": "string"
+        },
+        "tags": {
+            "$ref": "#/$defs/string_or_array_of_strings"
+        },
+        "copy_grants": {
+            "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "quote_columns": {
+            "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "column_types": {
+            "type": "object",
+            "patternProperties": {
+                "": {
+                    "type": "string"
+                }
+            }
+        },
+        "full_refresh": {
+            "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "alias": {
+            "type": "string"
+        },
+        "check_cols": {
+            "$ref": "#/$defs/string_or_array_of_strings"
+        },
+        "grants": {
+            "type": "object"
+        },
+        "strategy": {
+            "type": "string"
+        },
+        "target_database": {
+            "type": "string"
+        },
+        "target_schema": {
+            "type": "string"
+        },
+        "unique_key": {
+            "$ref": "#/$defs/string_or_array_of_strings"
+        },
+        "updated_at": {
+            "type": "string"
+        },
+        "error_if": {
+            "type": "string"
+        },
+        "fail_calc": {
+            "type": "string"
+        },
+        "limit": {
+            "type": "number"
+        },
+        "severity": {
+            "type": "string",
+            "enum": [
+                "warn",
+                "error"
+            ]
+        },
+        "store_failures": {
+            "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "warn_if": {
+            "type": "string"
         }
     }
 }

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -163,7 +163,7 @@
             }
         },
         "empty_directory": {
-            "type": "null"
+          "type": "null"
         },
         "boolean_or_jinja_string": {
             "oneOf": [
@@ -221,110 +221,82 @@
             "description": "Configurations set in the dbt_project.yml file will apply to all models that don't have a more specific configuration set.",
             "properties": {
                 "+bind": {
-                    "$ref": "#/$defs/bind"
+                    "$ref": "#/$defs/boolean_or_jinja_string",
+                    "default": false
                 },
                 "+database": {
-                    "$ref": "#/$defs/database"
+                    "type": "string"
                 },
                 "+docs": {
-                    "$ref": "#/$defs/docs"
+                    "$ref": "#/$defs/docs_config"
                 },
                 "+enabled": {
-                    "$ref": "#/$defs/enabled"
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+grant_access_to": {
-                    "$ref": "#/$defs/grant_access_to"
+                    "title": "Authorized views",
+                    "type": "array",
+                    "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "database": {
+                                "type": "string"
+                            },
+                            "project": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
                 },
                 "+hours_to_expiration": {
-                    "$ref": "#/$defs/hours_to_expiration"
+                    "type": "number",
+                    "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
                 },
                 "+incremental_strategy": {
-                    "$ref": "#/$defs/incremental_strategy"
+                    "type": "string"
                 },
                 "+kms_key_name": {
-                    "$ref": "#/$defs/kms_key_name"
+                    "type": "string",
+                    "description": "Configuration, specific to BigQuery adapter, of the KMS key name used for data encryption."
                 },
                 "+labels": {
-                    "$ref": "#/$defs/labels"
+                    "$ref": "#/$defs/label_configs"
                 },
                 "+materialized": {
-                    "$ref": "#/$defs/materialized"
+                    "type": "string"
                 },
                 "+on_schema_change": {
-                    "$ref": "#/$defs/on_schema_change"
+                    "type": "string",
+                    "enum": [
+                        "append_new_columns",
+                        "fail",
+                        "ignore",
+                        "sync_all_columns"
+                    ]
                 },
                 "+persist_docs": {
-                    "$ref": "#/$defs/persist_docs"
+                    "$ref": "#/$defs/persist_docs_config"
                 },
                 "+post-hook": {
-                    "$ref": "#/$defs/post-hook"
+                    "$ref": "#/$defs/array_of_strings"
                 },
                 "+pre-hook": {
-                    "$ref": "#/$defs/pre-hook"
+                    "$ref": "#/$defs/array_of_strings"
                 },
                 "+schema": {
-                    "$ref": "#/$defs/schema"
+                    "type": "string"
                 },
                 "+sql_header": {
-                    "$ref": "#/$defs/sql_header"
+                    "type": "string"
                 },
                 "+tags": {
-                    "$ref": "#/$defs/tags"
-                },
-                "bind": {
-                    "$ref": "#/$defs/bind"
-                },
-                "database": {
-                    "$ref": "#/$defs/database"
-                },
-                "docs": {
-                    "$ref": "#/$defs/docs"
-                },
-                "enabled": {
-                    "$ref": "#/$defs/enabled"
-                },
-                "grant_access_to": {
-                    "$ref": "#/$defs/grant_access_to"
-                },
-                "hours_to_expiration": {
-                    "$ref": "#/$defs/hours_to_expiration"
-                },
-                "incremental_strategy": {
-                    "$ref": "#/$defs/incremental_strategy"
-                },
-                "kms_key_name": {
-                    "$ref": "#/$defs/kms_key_name"
-                },
-                "labels": {
-                    "$ref": "#/$defs/labels"
-                },
-                "materialized": {
-                    "$ref": "#/$defs/materialized"
-                },
-                "on_schema_change": {
-                    "$ref": "#/$defs/on_schema_change"
-                },
-                "persist_docs": {
-                    "$ref": "#/$defs/persist_docs"
-                },
-                "post-hook": {
-                    "$ref": "#/$defs/post-hook"
-                },
-                "pre-hook": {
-                    "$ref": "#/$defs/pre-hook"
-                },
-                "schema": {
-                    "$ref": "#/$defs/schema"
-                },
-                "sql_header": {
-                    "$ref": "#/$defs/sql_header"
-                },
-                "tags": {
-                    "$ref": "#/$defs/tags"
+                    "$ref": "#/$defs/string_or_array_of_strings"
                 }
             },
             "additionalProperties": {
-                "oneOf": [
+                "oneOf" : [
                     {
                         "$ref": "#/$defs/model_configs"
                     },
@@ -355,62 +327,40 @@
             "type": "object",
             "properties": {
                 "+copy_grants": {
-                    "$ref": "#/$defs/copy_grants"
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+database": {
-                    "$ref": "#/$defs/database"
+                    "type": "string"
                 },
                 "+enabled": {
-                    "$ref": "#/$defs/enabled"
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+persist_docs": {
-                    "$ref": "#/$defs/persist_docs"
+                    "$ref": "#/$defs/persist_docs_config"
                 },
                 "+quote_columns": {
-                    "$ref": "#/$defs/quote_columns"
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+schema": {
-                    "$ref": "#/$defs/schema"
+                    "type": "string"
                 },
                 "+tags": {
-                    "$ref": "#/$defs/tags"
+                    "$ref": "#/$defs/string_or_array_of_strings"
                 },
                 "+column_types": {
-                    "$ref": "#/$defs/column_types"
+                    "type": "object",
+                    "patternProperties": {
+                        "": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "+full_refresh": {
-                    "$ref": "#/$defs/full_refresh"
-                },
-                "copy_grants": {
-                    "$ref": "#/$defs/copy_grants"
-                },
-                "database": {
-                    "$ref": "#/$defs/database"
-                },
-                "enabled": {
-                    "$ref": "#/$defs/enabled"
-                },
-                "persist_docs": {
-                    "$ref": "#/$defs/persist_docs"
-                },
-                "quote_columns": {
-                    "$ref": "#/$defs/quote_columns"
-                },
-                "schema": {
-                    "$ref": "#/$defs/schema"
-                },
-                "tags": {
-                    "$ref": "#/$defs/tags"
-                },
-                "column_types": {
-                    "$ref": "#/$defs/column_types"
-                },
-                "full_refresh": {
-                    "$ref": "#/$defs/full_refresh"
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 }
             },
             "additionalProperties": {
-                "oneOf": [
+                "oneOf" : [
                     {
                         "$ref": "#/$defs/seed_configs"
                     },
@@ -425,92 +375,50 @@
             "type": "object",
             "properties": {
                 "+alias": {
-                    "$ref": "#/$defs/alias"
+                    "type": "string"
                 },
                 "+check_cols": {
-                    "$ref": "#/$defs/check_cols"
+                    "$ref": "#/$defs/string_or_array_of_strings"
                 },
                 "+enabled": {
-                    "$ref": "#/$defs/enabled"
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+grants": {
-                    "$ref": "#/$defs/grants"
+                    "type": "object"
                 },
                 "+persist_docs": {
-                    "$ref": "#/$defs/persist_docs"
+                    "$ref": "#/$defs/persist_docs_config"
                 },
                 "+post-hook": {
-                    "$ref": "#/$defs/post-hook"
+                    "$ref": "#/$defs/array_of_strings"
                 },
                 "+pre-hook": {
-                    "$ref": "#/$defs/pre-hook"
+                    "$ref": "#/$defs/array_of_strings"
                 },
                 "+quote_columns": {
-                    "$ref": "#/$defs/quote_columns"
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+strategy": {
-                    "$ref": "#/$defs/strategy"
+                    "type": "string"
                 },
                 "+tags": {
-                    "$ref": "#/$defs/tags"
+                    "$ref": "#/$defs/string_or_array_of_strings"
                 },
                 "+target_database": {
-                    "$ref": "#/$defs/target_database"
+                    "type": "string"
                 },
                 "+target_schema": {
-                    "$ref": "#/$defs/target_schema"
+                    "type": "string"
                 },
                 "+unique_key": {
-                    "$ref": "#/$defs/unique_key"
+                    "$ref": "#/$defs/string_or_array_of_strings"
                 },
                 "+updated_at": {
-                    "$ref": "#/$defs/updated_at"
-                },
-                "alias": {
-                    "$ref": "#/$defs/alias"
-                },
-                "check_cols": {
-                    "$ref": "#/$defs/check_cols"
-                },
-                "enabled": {
-                    "$ref": "#/$defs/enabled"
-                },
-                "grants": {
-                    "$ref": "#/$defs/grants"
-                },
-                "persist_docs": {
-                    "$ref": "#/$defs/persist_docs"
-                },
-                "post-hook": {
-                    "$ref": "#/$defs/post-hook"
-                },
-                "pre-hook": {
-                    "$ref": "#/$defs/pre-hook"
-                },
-                "quote_columns": {
-                    "$ref": "#/$defs/quote_columns"
-                },
-                "strategy": {
-                    "$ref": "#/$defs/strategy"
-                },
-                "tags": {
-                    "$ref": "#/$defs/tags"
-                },
-                "target_database": {
-                    "$ref": "#/$defs/target_database"
-                },
-                "target_schema": {
-                    "$ref": "#/$defs/target_schema"
-                },
-                "unique_key": {
-                    "$ref": "#/$defs/unique_key"
-                },
-                "updated_at": {
-                    "$ref": "#/$defs/updated_at"
+                    "type": "string"
                 }
             },
             "additionalProperties": {
-                "oneOf": [
+                "oneOf" : [
                     {
                         "$ref": "#/$defs/snapshot_configs"
                     },
@@ -525,20 +433,14 @@
             "type": "object",
             "properties": {
                 "+enabled": {
-                    "$ref": "#/$defs/enabled"
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+tags": {
-                    "$ref": "#/$defs/tags"
-                },
-                "enabled": {
-                    "$ref": "#/$defs/enabled"
-                },
-                "tags": {
-                    "$ref": "#/$defs/tags"
+                    "$ref": "#/$defs/string_or_array_of_strings"
                 }
             },
             "additionalProperties": {
-                "oneOf": [
+                "oneOf" : [
                     {
                         "$ref": "#/$defs/source_configs"
                     },
@@ -564,74 +466,48 @@
             "description": "Configurations set in the dbt_project.yml file will apply to all tests that don't have a more specific configuration set.",
             "properties": {
                 "+alias": {
-                    "$ref": "#/$defs/alias"
+                    "type": "string",
+                    "description": "Only relevant when `store_failures` is true"
                 },
                 "+database": {
-                    "$ref": "#/$defs/database"
+                    "type": "string",
+                    "description": "Only relevant when `store_failures` is true"
                 },
                 "+enabled": {
-                    "$ref": "#/$defs/enabled"
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+error_if": {
-                    "$ref": "#/$defs/error_if"
+                    "type": "string"
                 },
                 "+fail_calc": {
-                    "$ref": "#/$defs/fail_calc"
+                    "type": "string"
                 },
                 "+limit": {
-                    "$ref": "#/$defs/limit"
+                    "type": "number"
                 },
                 "+schema": {
-                    "$ref": "#/$defs/schema"
+                    "type": "string",
+                    "description": "Only relevant when `store_failures` is true"
                 },
                 "+severity": {
-                    "$ref": "#/$defs/severity"
+                    "type": "string",
+                    "enum": [
+                        "warn",
+                        "error"
+                    ]
                 },
                 "+store_failures": {
-                    "$ref": "#/$defs/store_failures"
+                    "$ref": "#/$defs/boolean_or_jinja_string"
                 },
                 "+tags": {
-                    "$ref": "#/$defs/tags"
+                    "$ref": "#/$defs/string_or_array_of_strings"
                 },
                 "+warn_if": {
-                    "$ref": "#/$defs/warn_if"
-                },
-                "alias": {
-                    "$ref": "#/$defs/alias"
-                },
-                "database": {
-                    "$ref": "#/$defs/database"
-                },
-                "enabled": {
-                    "$ref": "#/$defs/enabled"
-                },
-                "error_if": {
-                    "$ref": "#/$defs/error_if"
-                },
-                "fail_calc": {
-                    "$ref": "#/$defs/fail_calc"
-                },
-                "limit": {
-                    "$ref": "#/$defs/limit"
-                },
-                "schema": {
-                    "$ref": "#/$defs/schema"
-                },
-                "severity": {
-                    "$ref": "#/$defs/severity"
-                },
-                "store_failures": {
-                    "$ref": "#/$defs/store_failures"
-                },
-                "tags": {
-                    "$ref": "#/$defs/tags"
-                },
-                "warn_if": {
-                    "$ref": "#/$defs/warn_if"
+                    "type": "string"
                 }
             },
             "additionalProperties": {
-                "oneOf": [
+                "oneOf" : [
                     {
                         "$ref": "#/$defs/test_configs"
                     },
@@ -640,143 +516,6 @@
                     }
                 ]
             }
-        },
-        "bind": {
-            "$ref": "#/$defs/boolean_or_jinja_string",
-            "default": false
-        },
-        "database": {
-            "type": "string"
-        },
-        "docs": {
-            "$ref": "#/$defs/docs_config"
-        },
-        "enabled": {
-            "$ref": "#/$defs/boolean_or_jinja_string"
-        },
-        "grant_access_to": {
-            "title": "Authorized views",
-            "type": "array",
-            "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "database": {
-                        "type": "string"
-                    },
-                    "project": {
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false
-            }
-        },
-        "hours_to_expiration": {
-            "type": "number",
-            "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
-        },
-        "incremental_strategy": {
-            "type": "string"
-        },
-        "kms_key_name": {
-            "type": "string",
-            "description": "Configuration, specific to BigQuery adapter, of the KMS key name used for data encryption."
-        },
-        "labels": {
-            "$ref": "#/$defs/label_configs"
-        },
-        "materialized": {
-            "type": "string"
-        },
-        "on_schema_change": {
-            "type": "string",
-            "enum": [
-                "append_new_columns",
-                "fail",
-                "ignore",
-                "sync_all_columns"
-            ]
-        },
-        "persist_docs": {
-            "$ref": "#/$defs/persist_docs_config"
-        },
-        "post-hook": {
-            "$ref": "#/$defs/array_of_strings"
-        },
-        "pre-hook": {
-            "$ref": "#/$defs/array_of_strings"
-        },
-        "schema": {
-            "type": "string"
-        },
-        "sql_header": {
-            "type": "string"
-        },
-        "tags": {
-            "$ref": "#/$defs/string_or_array_of_strings"
-        },
-        "copy_grants": {
-            "$ref": "#/$defs/boolean_or_jinja_string"
-        },
-        "quote_columns": {
-            "$ref": "#/$defs/boolean_or_jinja_string"
-        },
-        "column_types": {
-            "type": "object",
-            "patternProperties": {
-                "": {
-                    "type": "string"
-                }
-            }
-        },
-        "full_refresh": {
-            "$ref": "#/$defs/boolean_or_jinja_string"
-        },
-        "alias": {
-            "type": "string"
-        },
-        "check_cols": {
-            "$ref": "#/$defs/string_or_array_of_strings"
-        },
-        "grants": {
-            "type": "object"
-        },
-        "strategy": {
-            "type": "string"
-        },
-        "target_database": {
-            "type": "string"
-        },
-        "target_schema": {
-            "type": "string"
-        },
-        "unique_key": {
-            "$ref": "#/$defs/string_or_array_of_strings"
-        },
-        "updated_at": {
-            "type": "string"
-        },
-        "error_if": {
-            "type": "string"
-        },
-        "fail_calc": {
-            "type": "string"
-        },
-        "limit": {
-            "type": "number"
-        },
-        "severity": {
-            "type": "string",
-            "enum": [
-                "warn",
-                "error"
-            ]
-        },
-        "store_failures": {
-            "$ref": "#/$defs/boolean_or_jinja_string"
-        },
-        "warn_if": {
-            "type": "string"
         }
     }
 }

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -297,57 +297,7 @@
               }
             },
             "config": {
-              "type": "object",
-              "properties": {
-                "contract": {
-                  "$ref": "#/$defs/boolean_or_jinja_string"
-                },
-                "grant_access_to": {
-                  "title": "Authorized views",
-                  "type": "array",
-                  "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
-                  "items": {
-                    "type": "object",
-                    "required": ["database", "project"],
-                    "properties": {
-                      "database": {
-                        "type": "string"
-                      },
-                      "project": {
-                        "type": "string"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                },
-                "hours_to_expiration": {
-                  "type": "number",
-                  "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
-                },
-                "kms_key_name": {
-                  "type": "string",
-                  "description": "Configuration of the KMS key name, specific to BigQuery adapter.",
-                  "pattern": "projects/[a-zA-Z0-9_-]*/locations/[a-zA-Z0-9_-]*/keyRings/.*/cryptoKeys/.*"
-                },
-                "labels": {
-                  "title": "Label configs",
-                  "type": "object",
-                  "description": "Configuration specific to BigQuery adapter used to add labels and tags to tables/views created by dbt.",
-                  "patternProperties": {
-                    "^[a-z][a-z0-9_-]{0,62}$": {
-                      "type": "string",
-                      "pattern": "^[a-z0-9_-]{0,63}$"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "materialized": {
-                  "type": "string"
-                },
-                "sql_header": {
-                  "type": "string"
-                }
-              }
+              "$refs": "#/$defs/model_configs"
             },
             "contract": {
               "$ref": "#/$defs/boolean_or_jinja_string"
@@ -373,6 +323,29 @@
               "type": "array",
               "items": {
                 "$ref": "#/$defs/tests"
+              },
+            "versions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "v"
+                ],
+                "properties": {
+                  "v" : {"type": "number"},
+                  "config" : {"$ref": "#/$defs/model_configs"},
+                  "columns" : {
+                    "type": "object",
+                    "properties": {
+                      "include": {
+                        "$ref": "#/$defs/string_or_array_of_strings"
+                      },
+                      "exclude": {
+                        "$ref": "#/$defs/string_or_array_of_strings"
+                      }
+                    } 
+                  }
+                }
               }
             }
           },
@@ -774,6 +747,64 @@
       "jinja_string": {
         "type": "string",
         "pattern": "\\{\\{.*\\}\\}"
+      },
+      "model_configs": {
+        "type": "object",
+        "properties": {
+          "contract": {
+            "type" : "object",
+            "properties": {
+              "enforced" : {
+                "$ref": "#/$defs/boolean_or_jinja_string"
+              }
+            }
+          },
+          "grant_access_to": {
+            "title": "Authorized views",
+            "type": "array",
+            "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
+            "items": {
+              "type": "object",
+              "required": ["database", "project"],
+              "properties": {
+                "database": {
+                  "type": "string"
+                },
+                "project": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "hours_to_expiration": {
+            "type": "number",
+            "description": "Configuration specific to BigQuery adapter used to set an expiration delay (in hours) to a table."
+          },
+          "kms_key_name": {
+            "type": "string",
+            "description": "Configuration of the KMS key name, specific to BigQuery adapter.",
+            "pattern": "projects/[a-zA-Z0-9_-]*/locations/[a-zA-Z0-9_-]*/keyRings/.*/cryptoKeys/.*"
+          },
+          "labels": {
+            "title": "Label configs",
+            "type": "object",
+            "description": "Configuration specific to BigQuery adapter used to add labels and tags to tables/views created by dbt.",
+            "patternProperties": {
+              "^[a-z][a-z0-9_-]{0,62}$": {
+                "type": "string",
+                "pattern": "^[a-z0-9_-]{0,63}$"
+              }
+            },
+            "additionalProperties": false
+          },
+          "materialized": {
+            "type": "string"
+          },
+          "sql_header": {
+            "type": "string"
+          }
+        }
       },
       "number_or_jinja_string": {
         "oneOf": [

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -127,9 +127,6 @@
             "name": {
               "type": "string"
             },
-            "description": {
-              "type": "string"
-            },
             "owner": {
               "type": "object",
               "minProperties": 1,

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -300,30 +300,7 @@
               "$ref": "#/$defs/model_configs"
             },
             "constraints": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "columns": {
-                    "$ref": "#/$defs/string_or_array_of_strings"
-                  },
-                  "expression": { "type": "string" },
-                  "type": { "type": "string" },
-                  "name": { "type": "string" },
-                  "warn_unenforced": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
-                  },
-                  "warn_unsupported": {
-                    "$ref": "#/$defs/boolean_or_jinja_string"
-                  }
-                }
-              }
-            },
-            "contract": {
-              "$ref": "#/$defs/boolean_or_jinja_string"
+              "$ref": "#/$defs/constraints"
             },
             "description": {
               "type": "string"
@@ -357,14 +334,22 @@
                 "type": "object",
                 "required": ["v"],
                 "properties": {
-                  "v": { "type": "number" },
-                  "config": { "$ref": "#/$defs/model_configs" },
+                  "v": {
+                    "type": "number" 
+                  },
+                  "config": {
+                    "$ref": "#/$defs/model_configs" 
+                  },
                   "columns": {
                     "type": "array",
                     "items": {
                       "anyOf": [
-                        { "$ref": "#/$defs/include_exclude" },
-                        { "$ref": "#/$defs/column_properties" }
+                        {
+                          "$ref": "#/$defs/include_exclude" 
+                        },
+                        {
+                          "$ref": "#/$defs/column_properties"
+                        }
                       ]
                     }
                   }
@@ -684,10 +669,7 @@
             "type": "string"
           },
           "constraints": {
-            "$ref": "#/$defs/array_of_strings"
-          },
-          "constraints_check": {
-            "type": "string"
+            "$ref": "#/$defs/constraints"
           },
           "data_type": {
             "type": "string"
@@ -720,6 +702,33 @@
           }
         },
         "additionalProperties": false
+      },
+      "constraints": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "columns": {
+              "$ref": "#/$defs/string_or_array_of_strings"
+            },
+            "expression": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "warn_unenforced": {
+              "$ref": "#/$defs/boolean_or_jinja_string"
+            },
+            "warn_unsupported": {
+              "$ref": "#/$defs/boolean_or_jinja_string"
+            }
+          }
+        }
       },
       "freshness_definition": {
         "default": {

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -299,6 +299,26 @@
             "config": {
               "$refs": "#/$defs/model_configs"
             },
+            "constraints": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "columns": {
+                    "$ref": "#/$defs/string_or_array_of_strings"
+                  },
+                  "expression": { "type": "string" },
+                  "type": { "type": "string" },
+                  "name": { "type": "string" },
+                  "warn_unenforced": {
+                    "$ref": "#/$defs/boolean_or_jinja_string"
+                  },
+                  "warn_unsupported": {
+                    "$ref": "#/$defs/boolean_or_jinja_string"
+                  }
+                }
+              }
+            },
             "contract": {
               "$ref": "#/$defs/boolean_or_jinja_string"
             },
@@ -316,6 +336,9 @@
             "group": {
               "type": "string"
             },
+            "latest_version": {
+              "type": "number"
+            },
             "meta": {
               "type": "object"
             },
@@ -323,27 +346,24 @@
               "type": "array",
               "items": {
                 "$ref": "#/$defs/tests"
-              },
+              }
+            },
             "versions": {
               "type": "array",
               "items": {
                 "type": "object",
-                "required": [
-                  "v"
-                ],
+                "required": ["v"],
                 "properties": {
-                  "v" : {"type": "number"},
-                  "config" : {"$ref": "#/$defs/model_configs"},
-                  "columns" : {
-                    "type": "object",
-                    "properties": {
-                      "include": {
-                        "$ref": "#/$defs/string_or_array_of_strings"
-                      },
-                      "exclude": {
-                        "$ref": "#/$defs/string_or_array_of_strings"
-                      }
-                    } 
+                  "v": { "type": "number" },
+                  "config": { "$ref": "#/$defs/model_configs" },
+                  "columns": {
+                    "type": "array",
+                    "items": {
+                      "anyOf": [
+                        { "$ref": "#/$defs/include_exclude" },
+                        { "$ref": "#/$defs/column_properties" }
+                      ]
+                    }
                   }
                 }
               }
@@ -744,6 +764,17 @@
         },
         "additionalProperties": false
       },
+      "include_exclude": {
+        "type": "object",
+        "properties": {
+          "include": {
+            "$ref": "#/$defs/string_or_array_of_strings"
+          },
+          "exclude": {
+            "$ref": "#/$defs/string_or_array_of_strings"
+          }
+        }
+      },
       "jinja_string": {
         "type": "string",
         "pattern": "\\{\\{.*\\}\\}"
@@ -752,9 +783,9 @@
         "type": "object",
         "properties": {
           "contract": {
-            "type" : "object",
+            "type": "object",
             "properties": {
-              "enforced" : {
+              "enforced": {
                 "$ref": "#/$defs/boolean_or_jinja_string"
               }
             }

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -213,6 +213,20 @@
             ]
           },
           "properties": {
+              "config": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "treat_null_values_as_zero": {
+                  "$ref": "#/$defs/boolean_or_jinja_string"
+                },
+                "group": {
+                  "type": "string"
+                }
+              }
+            },
             "name": {
               "type": "string"
             },

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -302,6 +302,9 @@
                 }
               }
             },
+            "contract": {
+              "$ref": "#/$defs/boolean_or_jinja_string"
+            },
             "description": {
               "type": "string"
             },

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -118,6 +118,35 @@
           }
         }
       },
+      "groups": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name", "owner"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "object",
+              "minProperties": 1,
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "email": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
       "macros": {
         "type": "array",
         "items": {
@@ -246,6 +275,10 @@
             "name": {
               "type": "string"
             },
+            "access": {
+              "type": "string",
+              "enum": ["private", "protected", "public"]
+            },
             "columns": {
               "type": "array",
               "items": {
@@ -255,6 +288,9 @@
             "config": {
               "type": "object",
               "properties": {
+                "contract": {
+                  "$ref": "#/$defs/boolean_or_jinja_string"
+                },
                 "grant_access_to": {
                   "title": "Authorized views",
                   "type": "array",
@@ -315,6 +351,9 @@
                   "type": "boolean"
                 }
               }
+            },
+            "group": {
+              "type": "string"
             },
             "meta": {
               "type": "object"
@@ -635,6 +674,12 @@
         "required": ["name"],
         "properties": {
           "name": {
+            "type": "string"
+          },
+          "constraints": {
+            "$ref": "#/$defs/array_of_strings"
+          },
+          "constraints_check": {
             "type": "string"
           },
           "data_type": {

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -303,6 +303,9 @@
               "type": "array",
               "items": {
                 "type": "object",
+                "required": [
+                  "type"
+                ],
                 "properties": {
                   "columns": {
                     "$ref": "#/$defs/string_or_array_of_strings"

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -297,7 +297,7 @@
               }
             },
             "config": {
-              "$refs": "#/$defs/model_configs"
+              "$ref": "#/$defs/model_configs"
             },
             "constraints": {
               "type": "array",

--- a/tests/valid/dbt_project.yml
+++ b/tests/valid/dbt_project.yml
@@ -39,6 +39,10 @@ models:
       # same key without the plus
       materialized: table
     empty_subdirectory:
+    contracted_models:
+      +contract:
+        enforced: true
+    
   test_bq:
     +labels:
       key: val

--- a/tests/valid/schema.yml
+++ b/tests/valid/schema.yml
@@ -24,7 +24,8 @@ models:
     access: public
     group: analytics
     config:
-      contract: true
+      contract: 
+        enforced: true
     columns:
       - name: id
         description: "The primary key for this table"
@@ -35,6 +36,11 @@ models:
         tests:
           - unique
           - not_null
+    versions:
+      - v: 2
+        columns:
+          - include: '*'
+            exclude: country_name # this is the breaking 
 
 
 snapshots:

--- a/tests/valid/schema.yml
+++ b/tests/valid/schema.yml
@@ -21,6 +21,23 @@ models:
           - unique
           - not_null
 
+  - name: my_contracted_dbt_model
+    description: "A dbt model with contracts"
+    access: public
+    group: analytics
+    config:
+      contract: true
+    columns:
+      - name: id
+        description: "The primary key for this table"
+        constraints: 
+          - "not null"
+          - "unique"
+        constraints_check: (id > 0)
+        tests:
+          - unique
+          - not_null
+
 
 snapshots:
   - name: snapshot_name
@@ -28,3 +45,12 @@ snapshots:
     columns:
       - name: id 
         description: cool column, eh?
+
+
+# model groups 
+
+groups:
+  - name: analytics
+    owner:
+      name: dave
+      

--- a/tests/valid/schema.yml
+++ b/tests/valid/schema.yml
@@ -23,12 +23,14 @@ models:
     description: "A dbt model with contracts"
     access: public
     group: analytics
+    latest_version: 2
     config:
       contract: 
         enforced: true
     columns:
       - name: id
         description: "The primary key for this table"
+        data_type: int
         constraints: 
           - "not null"
           - "unique"
@@ -40,7 +42,26 @@ models:
       - v: 2
         columns:
           - include: '*'
-            exclude: country_name # this is the breaking 
+            exclude: country_name
+          - name: id  # included in addition the '*' set. if customer_id were in the '*' set -> override it
+            description: This is the primary key
+            data_type: float
+      - v: 1
+        config:
+          alias: dim_customers
+  
+  - name: my_model_level_contract_model
+    config:
+      contract:
+        enforced: true
+    constraints:
+    - type: check
+      expression: (id > 0)
+    - type: primary_key
+      columns: [ id ]
+    - type: unique
+      columns: [ color, date_day ]
+      name: strange_uniqueness_requirement
 
 
 snapshots:

--- a/tests/valid/schema.yml
+++ b/tests/valid/schema.yml
@@ -32,9 +32,10 @@ models:
         description: "The primary key for this table"
         data_type: int
         constraints: 
-          - "not null"
-          - "unique"
-        constraints_check: (id > 0)
+          - type: not_null
+          - type: unique
+          - type: check
+            expression: (id > 0)
         tests:
           - unique
           - not_null
@@ -43,7 +44,7 @@ models:
         columns:
           - include: '*'
             exclude: country_name
-          - name: id  # included in addition the '*' set. if customer_id were in the '*' set -> override it
+          - name: id  # included in addition the '*' set. if id were in the '*' set -> override it
             description: This is the primary key
             data_type: float
       - v: 1


### PR DESCRIPTION
This PR adds the configs for the upcoming 1.5 dbt core concepts for model contracts

you can:

For projects:
- define groups of models in `_resource.yml` files.

For models
- define `access` - whether the model is public/private/protected
- define `contract` - whether the model is subject to a model contract
- define `group` - assign a model to a group

For columns:
- define `constraint` - add a database constraint to the model
- define `constraint_check` add a SQL check on the column 

For metrics:
- define `groups` in `config` -- sneaking in a config object, as metrics will be able to be grouped -- adding the other two metric configs while I was in there (can split this out if we'd prefer to sequence these more thoughtfully)