### PR TITLE
Bigquery labels lengths, key chars

### DIFF
--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -287,9 +287,9 @@
                   "type": "object",
                   "description": "Configuration specific to BigQuery adapter used to add labels and tags to tables/views created by dbt.",
                   "patternProperties": {
-                    "^[a-z][a-z0-9]{0,63}$": {
+                    "^[a-z][a-z0-9_-]{0,62}$": {
                       "type": "string",
-                      "pattern": "^[a-z0-9_-]{0,64}$"
+                      "pattern": "^[a-z0-9_-]{0,63}$"
                     }
                   },
                   "additionalProperties": false


### PR DESCRIPTION
https://cloud.google.com/bigquery/docs/labels-intro#requirements

Keys have a minimum length of 1 character and a maximum length of 63 characters, and cannot be empty. Values can be empty, and have a maximum length of 63 characters.

Keys and values can contain only lowercase letters, numeric characters, underscores, and dashes. All characters must use UTF-8 encoding, and international characters are allowed.