### PR TITLE
allow package specifications in dependencies.yml

### DIFF
--- a/schemas/1.6/dependencies-1.6.json
+++ b/schemas/1.6/dependencies-1.6.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "dependencies",
-  "required": ["projects"],
   "properties": {
     "projects": {
       "type": "array",
@@ -16,6 +15,68 @@
         },
         "additionalProperties": false
       }
+    },
+    "packages": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "required": ["package", "version"],
+            "properties": {
+              "version": {
+                "title": "Package version",
+                "type": ["string", "number", "array"],
+                "description": "A semantic version string or range, such as [\">=1.0.0\", \"<2.0.0\"]"
+              },
+              "install-prerelease": {
+                "title": "Install Prerelease",
+                "type": "boolean",
+                "description": "Opt in to prerelease versions of a package"
+              },
+              "package": {
+                "title": "Package identifier",
+                "type": "string",
+                "description": "Must be in format `org_name/package_name`. Refer to hub.getdbt.com for installation instructions",
+                "examples": ["dbt-labs/dbt_utils"],
+                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": ["git"],
+            "properties": {
+              "git": {
+                "title": "Git URL",
+                "type": "string"
+              },
+              "revision": {
+                "title": "Revision",
+                "type": "string",
+                "description": "Pin your package to a specific release by specifying a release name"
+              },
+              "subdirectory": {
+                "title": "Subdirectory",
+                "type": "string",
+                "description": "Only required if the package is nested in a subdirectory of the git project"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "local": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "minItems": 1
     }
   },
   "additionalProperties": false

--- a/tests/1.6/invalid/dependencies.yml
+++ b/tests/1.6/invalid/dependencies.yml
@@ -1,2 +1,6 @@
 projects:
   - gnome: my_dbt_project
+
+pancakeages:
+  - pancake: dbt-labs/dbt-utils
+    version: 1.0.0

--- a/tests/1.6/valid/dependencies.yml
+++ b/tests/1.6/valid/dependencies.yml
@@ -1,2 +1,6 @@
 projects:
   - name: my_dbt_project
+
+packages:
+  - package: dbt-labs/dbt-utils
+    version: 1.0.0


### PR DESCRIPTION
packages are allowed in `dependencies.yml`! who knew! @joellabes [knew](https://github.com/dbt-labs/dbt-core/issues/7631)

closes #81 (mostly)