### PR TITLE
Add uniqueness validation for column

### DIFF
--- a/schemas/1.5/dbt_yml_files-1.5.json
+++ b/schemas/1.5/dbt_yml_files-1.5.json
@@ -713,7 +713,8 @@
           "$ref": "#/$defs/string_or_array_of_strings"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "uniqueItems": true
     },
     "constraints": {
       "type": "array",

--- a/schemas/1.6/dbt_yml_files-1.6.json
+++ b/schemas/1.6/dbt_yml_files-1.6.json
@@ -713,7 +713,8 @@
           "$ref": "#/$defs/string_or_array_of_strings"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "uniqueItems": true
     },
     "constraints": {
       "type": "array",

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -713,7 +713,8 @@
             "$ref": "#/$defs/string_or_array_of_strings"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "uniqueItems": true
       },
       "constraints": {
         "type": "array",


### PR DESCRIPTION
When a developer is entering column information into yaml, sometimes duplicate column names are entered. For example, this is the case.

```yaml
version: 2
models:
  - name: my_model
    columns:
      - name: user_id
      - name: user_name
      - ...
      - name: user_id
```

I wanted dbt-jsonschema to check for such cases, so I added `"uniqueItems": true`.