### PR TITLE
Correct grant_access_to dataset property

### DIFF
--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -739,7 +739,7 @@
       "items": {
         "type": "object",
         "properties": {
-          "database": {
+          "dataset": {
             "type": "string"
           },
           "project": {


### PR DESCRIPTION
The [dbt docs on authorized views](https://docs.getdbt.com/reference/resource-configs/bigquery-configs#authorized-views) define the property as `dataset`, not `database`. Using `database` makes dbt throw an error.