### PR TITLE
NULL schemas are allowed

### DIFF
--- a/schemas/1.5/dbt_project-1.5.json
+++ b/schemas/1.5/dbt_project-1.5.json
@@ -813,7 +813,7 @@
       "type": "object"
     },
     "schema": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "sql_header": {
       "type": "string"

--- a/schemas/1.6/dbt_project-1.6.json
+++ b/schemas/1.6/dbt_project-1.6.json
@@ -781,7 +781,7 @@
       "type": "object"
     },
     "schema": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "sql_header": {
       "type": "string"

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -804,7 +804,7 @@
       "enum": ["append_new_columns", "fail", "ignore", "sync_all_columns"]
     },
     "schema": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "sql_header": {
       "type": "string"


### PR DESCRIPTION
We can use null/empty schemas in `dbt_project.yml`, we actually do it in IA (and we currently get errors because NULL is not allowed)