### PR TITLE
enabled additionalProperties for groups

### DIFF
--- a/schemas/1.5/dbt_yml_files-1.5.json
+++ b/schemas/1.5/dbt_yml_files-1.5.json
@@ -138,7 +138,7 @@
                 "type": "string"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": true
           }
         },
         "additionalProperties": false

--- a/schemas/1.6/dbt_yml_files-1.6.json
+++ b/schemas/1.6/dbt_yml_files-1.6.json
@@ -138,7 +138,7 @@
                 "type": "string"
               }
             },
-            "additionalProperties": false
+            "additionalProperties": true
           }
         },
         "additionalProperties": false

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -135,7 +135,7 @@
                   "type": "string"
                 }
               },
-              "additionalProperties": false
+              "additionalProperties": true
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-jsonschema/issues/101

Set additionalProperties=true for groups owner

`"additionalProperties": false`
![image](https://github.com/dbt-labs/dbt-jsonschema/assets/7255359/a056ddfb-4d08-4181-bc10-24110d612b13)

`"additionalProperties": true`
![image](https://github.com/dbt-labs/dbt-jsonschema/assets/7255359/4d13d487-772a-4a27-b2cd-0f487ea9eb1e)
