### PR TITLE
Add: dbt-cloud CLI config to `dbt_project.json`

### DIFF
--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -23,6 +23,16 @@
       "type": "number",
       "default": 2
     },
+    "dbt-cloud": {
+      "type": "object",
+      "description": "dbt cloud CLI configurations.",
+      "properties": {
+        "project-id": {
+          "description": "ID of the dbt cloud project which cloud CLI commands will be run against.",
+          "type": integer
+        }
+      }
+    },
     "dispatch": {
       "type": "array",
       "items": {

--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -29,7 +29,7 @@
       "properties": {
         "project-id": {
           "description": "ID of the dbt cloud project which cloud CLI commands will be run against.",
-          "type": integer
+          "type": "integer"
         }
       }
     },


### PR DESCRIPTION
Adds dbt-cloud CLI config to `dbt_project.json` to prevent linting error from showing up in `dbt_project.yml`.

<img width="783" alt="image" src="https://github.com/dbt-labs/dbt-jsonschema/assets/28986302/a0b577b0-594f-44b7-85c0-3a35f0181700">
 