### PR TITLE
add dbt-cloud specific parameters as specified in docs

### DIFF
--- a/schemas/dbt_project.json
+++ b/schemas/dbt_project.json
@@ -23,6 +23,17 @@
       "type": "number",
       "default": 2
     },
+    "dbt-cloud": {
+      "type": "object",
+      "properties": {
+        "project-id": {
+          "type": "string"
+        },
+        "defer-env-id": {
+          "type": "string"
+        }
+      }
+    },
     "dispatch": {
       "type": "array",
       "items": {


### PR DESCRIPTION
As specified [in the docs](https://docs.getdbt.com/reference/dbt_project.yml), since v1.6 the dbt-cloud parameter is allowed. 