### PR TITLE
Add data tests

### DIFF
--- a/schemas/latest/dbt_project-latest.json
+++ b/schemas/latest/dbt_project-latest.json
@@ -24,6 +24,9 @@
     "config-version": {
       "type": "number",
       "default": 2
+    },    
+    "data_tests": {
+      "$ref": "#/$defs/data_test_configs"
     },
     "dbt-cloud": {
       "type": "object",

--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -977,6 +977,123 @@
         }
       }
     },
+    "data_tests": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "title": "Relationships Test",
+          "type": "object",
+          "properties": {
+            "relationships": {
+              "type": "object",
+              "required": [
+                "to",
+                "field"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "config": {
+                  "$ref": "#/$defs/test_configs"
+                },
+                "field": {
+                  "title": "Relationships: Field",
+                  "description": "The foreign key column",
+                  "type": "string",
+                  "default": "<FOREIGN_KEY_COLUMN>"
+                },
+                "to": {
+                  "type": "string",
+                  "default": "ref('')",
+                  "examples": [
+                    "ref('parent_model')",
+                    "source('parent_schema', 'parent_table')"
+                  ]
+                },
+                "where": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Accepted Values Test",
+          "type": "object",
+          "properties": {
+            "accepted_values": {
+              "type": "object",
+              "required": [
+                "values"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "config": {
+                  "$ref": "#/$defs/test_configs"
+                },
+                "quote": {
+                  "type": "boolean"
+                },
+                "values": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "where": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Not Null Test",
+          "type": "object",
+          "properties": {
+            "not_null": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "config": {
+                  "$ref": "#/$defs/test_configs"
+                },
+                "where": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "Unique Test",
+          "type": "object",
+          "properties": {
+            "unique": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "config": {
+                  "$ref": "#/$defs/test_configs"
+                },
+                "where": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
     "dimension": {
       "type": "object",
       "required": [
@@ -1555,123 +1672,6 @@
           "type": "string"
         }
       }
-    },
-    "data_tests": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "title": "Relationships Test",
-          "type": "object",
-          "properties": {
-            "relationships": {
-              "type": "object",
-              "required": [
-                "to",
-                "field"
-              ],
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "config": {
-                  "$ref": "#/$defs/test_configs"
-                },
-                "field": {
-                  "title": "Relationships: Field",
-                  "description": "The foreign key column",
-                  "type": "string",
-                  "default": "<FOREIGN_KEY_COLUMN>"
-                },
-                "to": {
-                  "type": "string",
-                  "default": "ref('')",
-                  "examples": [
-                    "ref('parent_model')",
-                    "source('parent_schema', 'parent_table')"
-                  ]
-                },
-                "where": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Accepted Values Test",
-          "type": "object",
-          "properties": {
-            "accepted_values": {
-              "type": "object",
-              "required": [
-                "values"
-              ],
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "config": {
-                  "$ref": "#/$defs/test_configs"
-                },
-                "quote": {
-                  "type": "boolean"
-                },
-                "values": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "where": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Not Null Test",
-          "type": "object",
-          "properties": {
-            "not_null": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "config": {
-                  "$ref": "#/$defs/test_configs"
-                },
-                "where": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Unique Test",
-          "type": "object",
-          "properties": {
-            "unique": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "config": {
-                  "$ref": "#/$defs/test_configs"
-                },
-                "where": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      ]
     },
     "validity_params": {
       "type": "object",

--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -831,7 +831,7 @@
             }
           },
           "model": {
-            "description": "The name of the model whose behaviour you are testing. Does not need to wrapped in a ref.",
+            "description": "The name of the model whose behaviour you are testing. Does not need to be wrapped in a ref.",
             "type": "string",
             "examples": [
               "my_model"

--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -284,6 +284,12 @@
           "constraints": {
             "$ref": "#/$defs/constraints"
           },
+          "data_tests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/data_tests"
+            }
+          },
           "docs": {
             "$ref": "#/$defs/docs_config"
           },
@@ -299,7 +305,7 @@
           "tests": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/tests"
+              "$ref": "#/$defs/data_tests"
             }
           },
           "versions": {
@@ -365,6 +371,12 @@
               "copy_grants": {
                 "$ref": "#/$defs/boolean_or_jinja_string"
               },
+              "data_tests": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/data_tests"
+                }
+              },
               "database": {
                 "type": "string"
               },
@@ -391,7 +403,7 @@
           "tests": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/tests"
+              "$ref": "#/$defs/data_tests"
             }
           }
         },
@@ -519,6 +531,12 @@
               }
             }
           },
+          "data_tests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/data_tests"
+            }
+          },
           "docs": {
             "$ref": "#/$defs/docs_config"
           },
@@ -531,7 +549,7 @@
           "tests": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/tests"
+              "$ref": "#/$defs/data_tests"
             }
           }
         },
@@ -555,6 +573,12 @@
           },
           "config": {
             "type": "object"
+          },
+          "data_tests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/data_tests"
+            }
           },
           "database": {
             "type": "string"
@@ -659,7 +683,7 @@
                 "tests": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/$defs/tests"
+                    "$ref": "#/$defs/data_tests"
                   }
                 }
               },
@@ -672,7 +696,7 @@
           "tests": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/tests"
+              "$ref": "#/$defs/data_tests"
             }
           }
         }
@@ -889,6 +913,12 @@
         "constraints": {
           "$ref": "#/$defs/constraints"
         },
+        "data_tests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/data_tests"
+          }
+        },
         "data_type": {
           "type": "string"
         },
@@ -912,7 +942,7 @@
         "tests": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/tests"
+            "$ref": "#/$defs/data_tests"
           }
         }
       },
@@ -1526,7 +1556,7 @@
         }
       }
     },
-    "tests": {
+    "data_tests": {
       "anyOf": [
         {
           "type": "string"


### PR DESCRIPTION
Resolves #124 by renaming the tests def to data_tests, and adding an additional ref called data_tests to every block where a tests block already existed. 

The huge diff from line 800 to line 1600 (ish) is solely due to a rename of the key and then re-sorting the json accordingly, so feel free to ignore that. 