### PR TITLE
Add +docs to seeds and snapshots

### DIFF
--- a/schemas/latest/dbt_project-latest.json
+++ b/schemas/latest/dbt_project-latest.json
@@ -747,6 +747,9 @@
         "database": {
           "$ref": "#/$defs/database"
         },
+        "docs": {
+          "$ref": "#/$defs/docs_config"
+        },
         "enabled": {
           "$ref": "#/$defs/boolean_or_jinja_string"
         },
@@ -869,6 +872,9 @@
         },
         "check_cols": {
           "$ref": "#/$defs/string_or_array_of_strings"
+        },
+        "docs": {
+          "$ref": "#/$defs/docs_config"
         },
         "enabled": {
           "$ref": "#/$defs/boolean_or_jinja_string"

--- a/schemas/latest/dbt_project-latest.json
+++ b/schemas/latest/dbt_project-latest.json
@@ -705,6 +705,9 @@
         "+database": {
           "$ref": "#/$defs/database"
         },
+        "+docs": {
+          "$ref": "#/$defs/docs_config"
+        },
         "+enabled": {
           "$ref": "#/$defs/boolean_or_jinja_string"
         },
@@ -809,6 +812,9 @@
         },
         "+check_cols": {
           "$ref": "#/$defs/string_or_array_of_strings"
+        },
+        "+docs": {
+          "$ref": "#/$defs/docs_config"
         },
         "+enabled": {
           "$ref": "#/$defs/boolean_or_jinja_string"


### PR DESCRIPTION
I tested in dbt 1.7 and both seeds and snapshots support docs config in dbt_project.yml