### PR TITLE
fix: add missing deprecation_date field to models schema

### DIFF
--- a/schemas/1.6/dbt_yml_files-1.6.json
+++ b/schemas/1.6/dbt_yml_files-1.6.json
@@ -248,6 +248,9 @@
           "description": {
             "type": "string"
           },
+          "deprecation_date": {
+            "type": "string"
+          },
           "docs": {
             "$ref": "#/$defs/docs_config"
           },

--- a/schemas/1.7/dbt_yml_files-1.7.json
+++ b/schemas/1.7/dbt_yml_files-1.7.json
@@ -248,6 +248,9 @@
           "description": {
             "type": "string"
           },
+          "deprecation_date": {
+            "type": "string"
+          },
           "docs": {
             "$ref": "#/$defs/docs_config"
           },

--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -265,6 +265,9 @@
           "description": {
             "type": "string"
           },
+          "deprecation_date": {
+            "type": "string"
+          },
           "access": {
             "type": "string",
             "enum": [


### PR DESCRIPTION
The `deprecation_date` field is a new model property added in v1.6 per upgrade notes [here](https://docs.getdbt.com/docs/dbt-versions/core-upgrade/upgrading-to-v1.6#for-consumers-of-dbt-artifacts-metadata).

This field is supported in all dbt-core versions >=1.6, docs here:
- https://docs.getdbt.com/reference/resource-properties/deprecation_date
- https://docs.getdbt.com/reference/model-properties
![image](https://github.com/dbt-labs/dbt-jsonschema/assets/40754858/97aea2a3-6c40-4dc9-871d-e8902ea792b5)
