### PR TITLE
add sql as approved unit test format

### DIFF
--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -905,7 +905,7 @@
             "else": {
               "properties": {
                 "rows": {
-                  "description": "When `format` is csv, a string containing comma-separated headers and values. Alternatively provide a fixture. Use the pipe character | to create a multi-line string in YAML.",
+                  "description": "When `format` is csv or sql, a string containing comma-separated headers and values. Alternatively provide a fixture. Use the pipe character | to create a multi-line string in YAML.",
                   "type": "string"
                 }
               }
@@ -920,6 +920,7 @@
                 "type": "string",
                 "enum": [
                   "dict",
+                  "sql",
                   "csv"
                 ]
               },
@@ -951,7 +952,7 @@
               "else": {
                 "properties": {
                   "rows": {
-                    "description": "When `format` is csv, a string containing comma-separated headers and values. Alternatively provide a fixture. Use the pipe character | to create a multi-line string in YAML.",
+                    "description": "When `format` is csv or sql, a string containing comma-separated headers and values. Alternatively provide a fixture. Use the pipe character | to create a multi-line string in YAML.",
                     "type": "string"
                   }
                 }
@@ -966,7 +967,8 @@
                   "type": "string",
                   "enum": [
                     "dict",
-                    "csv"
+                    "csv",
+                    "sql"
                   ]
                 },
                 "input": {

--- a/tests/latest/valid/dbt_yml_files.yml
+++ b/tests/latest/valid/dbt_yml_files.yml
@@ -123,6 +123,26 @@ unit_tests:
         count
         2
 
+  - name: my_sql_unit_test
+    model: unit_reworked_compare_struct
+    given:
+      - input: ref('unit_test_struct_model_a')
+        format: sql
+        rows: |
+          select 1 as id, 'John Doe' as col1, object_construct('street', '123 Main St', 'city', 'Anytown', 'state', 'CA') as col2
+      - input: ref('unit_test_struct_model_b')
+        format: sql
+        rows: |
+          select 1 as id, 'John Doe' as col1, object_construct('street', '123 Main St', 'city', 'Anytown', 'state', 'CA') as col2
+    expect:
+      rows:
+        - {"id": 1, "dbt_audit_row_status": "identical", "dbt_audit_num_rows_in_status": 1}
+    overrides:
+      vars:
+        reworked_compare__columns: ['id', 'col1', 'col2']
+        reworked_compare__event_time:
+        reworked_compare__primary_key_columns: ['id']
+
 snapshots:
   - name: snapshot_name
     group: analytics


### PR DESCRIPTION
allows `sql` as an allowed unit test format -- gratefully, the csv format is the same and the only logic change is to add sql to the enum