### PR TITLE
Updated metric_input_measure to reflect correctly on what it can be

### DIFF
--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -1753,29 +1753,36 @@
       "additionalProperties": false
     },
     "metric_input_measure": {
-      "type": "object",
-      "properties": {
-        "name": {
+      "oneOf": [
+        {
           "type": "string"
         },
-        "fill_nulls_with": {
-          "anyOf": [
-            {
+        {
+          "type": "object",
+          "properties": {
+            "name": {
               "type": "string"
             },
-            {
-              "type": "integer"
+            "fill_nulls_with": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "filter": {
+              "type": "string"
+            },
+            "join_to_timespine": {
+              "type": "boolean"
             }
-          ]
-        },
-        "filter": {
-          "type": "string"
-        },
-        "join_to_timespine": {
-          "type": "boolean"
+          },
+          "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      ]
     },
     "metric_input_schema": {
       "type": "object",

--- a/tests/latest/valid/dbt_yml_files.yml
+++ b/tests/latest/valid/dbt_yml_files.yml
@@ -216,6 +216,15 @@ metrics:
     filter: |
       {{ Dimension('customer__customer_type') }}  = 'new'
 
+  - name: recurring_customer
+    description: Unique count of recurring customers.
+    label: Recurring Customers
+    type: simple
+    type_params:
+      measure: customers_with_orders
+    filter: |
+      {{ Dimension('customer__customer_type') }}  = 'recurring'
+
   - name: average_transaction_total_us
     description: "The average total for each transaction in the US"
     label: Transaction Total Average US


### PR DESCRIPTION
## Context
In dbt and in SL, the definition of the metric_input_measure can be either a string or an object. There is some logic to convert the string to an object if that is provided. However, in the schema it shows that it can only be an object. This is causing warnings to show up on the IDE even though it is parseable.

![image](https://github.com/user-attachments/assets/bf5e541f-b22b-41f9-959d-a8bc80f58b4d)
