### PR TITLE
fix: data_tests.

### DIFF
--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -820,6 +820,12 @@
                     "$ref": "#/$defs/column_properties"
                   }
                 },
+                "data_tests": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/data_tests"
+                  }
+                },
                 "external": {
                   "type": "object"
                 },


### PR DESCRIPTION
`sources.tables.data_tesets` was not defined, so it was added.

https://github.com/dbt-labs/dbt-jsonschema/pull/162#issuecomment-2359942378