### PR TITLE
Allow config blocks in sources' tables, add event_time

### DIFF
--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -1835,6 +1835,10 @@
             }
           }
         },
+        "event_time": {
+          "type": "string",
+          "description": "The column that represents the actual moment the row's event happened. Contrast with, for example, when it was loaded to the warehouse."
+        },
         "file_format": {
           "type": "string"
         },

--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -820,6 +820,16 @@
                     "$ref": "#/$defs/column_properties"
                   }
                 },
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "event_time": {
+                      "type": "string",
+                      "description": "The column that represents the actual moment the row's event happened. Contrast with, for example, when it was loaded to the warehouse."
+                    },
+                    "additionalProperties": true
+                  }
+                },
                 "data_tests": {
                   "type": "array",
                   "items": {

--- a/tests/latest/valid/dbt_yml_files.yml
+++ b/tests/latest/valid/dbt_yml_files.yml
@@ -1,5 +1,3 @@
-# this file was generated with dbt init with dbt 1.2.1
-
 models:
   - name: my_first_dbt_model
     description: "A starter dbt model"
@@ -298,3 +296,25 @@ saved_queries:
           alias: my_export_alias
           export_as: table
           schema: my_export_schema_name
+
+
+sources:
+  - name: some_source_name
+    loaded_at_field: _etl_loaded_at
+    freshness: 
+      error_after:
+        count: 2
+        period: day
+      warn_after:
+        count: 1
+        period: day
+    tables:
+      - name: some_table_name
+        config:
+          event_time: "created_at"
+      - name: another_table_name
+        columns:
+          - name: my_unique_column
+            description: This sure is a column
+            data_tests:
+              - unique

--- a/tests/latest/valid/dbt_yml_files.yml
+++ b/tests/latest/valid/dbt_yml_files.yml
@@ -32,6 +32,7 @@ models:
     config:
       contract: 
         enforced: true
+      event_time: "created_at"
     columns:
       - name: id
         description: "The primary key for this table"


### PR DESCRIPTION
Resolves #164 by adding support for configs in tables on sources. Added event_time support while I was there. 