### PR TITLE
Replace database for dataset in grant_access_to

### DIFF
--- a/schemas/latest/dbt_project-latest.json
+++ b/schemas/latest/dbt_project-latest.json
@@ -430,7 +430,7 @@
       "items": {
         "type": "object",
         "properties": {
-          "database": {
+          "dataset": {
             "type": "string"
           },
           "project": {


### PR DESCRIPTION
The [Authorized Views docs](https://docs.getdbt.com/reference/resource-configs/bigquery-configs#authorized-views) wants `dataset` not `database` for authorized view grants. This should fix the issue raised in #158 