### PR TITLE
Updated schema to reflect custom calendar changes

### DIFF
--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -348,19 +348,7 @@
             "type": "string"
           },
           "time_granularity": {
-            "enum": [
-              "nanosecond",
-              "microsecond",
-              "millisecond",
-              "second",
-              "minute",
-              "hour",
-              "day",
-              "week",
-              "month",
-              "quarter",
-              "year"
-            ]
+            "type": "string"
           },
           "type_params": {
             "type": "object"
@@ -1329,19 +1317,7 @@
               "type": "string"
             },
             "grain_to_date": {
-              "enum": [
-                "nanosecond",
-                "microsecond",
-                "millisecond",
-                "second",
-                "minute",
-                "hour",
-                "day",
-                "week",
-                "month",
-                "quarter",
-                "year"
-              ]
+              "type": "string"
             },
             "period_agg": {
               "enum": [
@@ -1881,6 +1857,9 @@
         },
         "filter": {
           "type": "string"
+        },
+        "offset_to_grain": {
+            "type": "string"
         },
         "offset_window": {
           "type": "string"


### PR DESCRIPTION
## Context
You can now specify custom granularity now, so changing type to a string instead of an enum for `Metric.time_granularity` and `CumulativeTypeParams.grain_to_date`. Additionally, seems like `MetricInput.offset_to_grain` was missing, so adding that

Resolves SL-3100
