### PR TITLE
Add Tags to Semantic Layer Saved Queries

### DIFF
--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -524,6 +524,19 @@
               "additionalProperties": false
             }
           },
+          "tags": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
           "config": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
Title says it all.

This is modeled off of this [previous PR](https://github.com/dbt-labs/dbt-jsonschema/pull/155) adding features to Semantic Layer objects.

Linked PRs:
* the starting point at [dbt-semantic-interfaces](https://github.com/dbt-labs/dbt-semantic-interfaces/pull/366/files)
* [dbt-core](https://github.com/dbt-labs/dbt-core/pull/10987)
* [schemas.dbt.com](https://github.com/dbt-labs/schemas.getdbt.com/pull/75)

Example of how this would look in an actual saved
query in a yml file:
```
saved_queries:
- name: with_list_tags_v2
    tags: ['tag_b', 'tag_d', 'tag_a']
    description: New customer orders by name and time
    query_params:
      metrics:
        - orders
      group_by:
        - Dimension('customer__customer_name')
        - TimeDimension('metric_time', 'day')
      where:
        - "{{ Dimension('customer__customer_type') }}  = 'new'"
    exports:
      - name: new_customer_orders_table
        config:
          export_as: table
      - name: new_customer_orders_view
        config:
          export_as: view
          alias: new_customer_orders_export_alias
          testing: "what"
          breaking: 'break it now'
```

If there's any testing I should do for this, please lmk. :-)