### PR TITLE
[tests] complete `unique` and `not_null` as strings by default

### DIFF
--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -1479,9 +1479,7 @@
                 }
               }
             }
-          },
-          "minProperties": 1,
-          "maxProperties": 1
+          }
         }
       ]
     },

--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -1390,6 +1390,7 @@
         {
           "type": "string"
         },
+        { "enum": ["unique", "not_null"] },
         {
           "title": "Relationships Test",
           "type": "object",
@@ -1461,10 +1462,10 @@
           }
         },
         {
-          "title": "Not Null Test",
+          "title": "User defined test",
           "type": "object",
-          "properties": {
-            "not_null": {
+          "patternProperties": {
+            ".*": {
               "type": "object",
               "properties": {
                 "name": {
@@ -1478,27 +1479,9 @@
                 }
               }
             }
-          }
-        },
-        {
-          "title": "Unique Test",
-          "type": "object",
-          "properties": {
-            "unique": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "config": {
-                  "$ref": "#/$defs/test_configs"
-                },
-                "where": {
-                  "type": "string"
-                }
-              }
-            }
-          }
+          },
+          "minProperties": 1,
+          "maxProperties": 1
         }
       ]
     },


### PR DESCRIPTION
<img width="549" alt="image" src="https://github.com/user-attachments/assets/4e0f06da-68e2-4c8c-8d86-ff2fa8002858" />

Still supports config/where/name for `unique`:
<img width="490" alt="image" src="https://github.com/user-attachments/assets/c46c0300-6404-436a-aaff-462c1e1def01" />

and 🆕 for arbitrary user defined tests:
<img width="192" alt="image" src="https://github.com/user-attachments/assets/c9642e99-d3ad-406b-89c5-d42ca0732986" />

