### PR TITLE
Fix `limit` and `config-version` types to be integer, not number

### DIFF
--- a/schemas/latest/dbt_project-latest.json
+++ b/schemas/latest/dbt_project-latest.json
@@ -22,7 +22,7 @@
       "$ref": "#/$defs/array_of_strings"
     },
     "config-version": {
-      "type": "number",
+      "type": "integer",
       "default": 2
     },
     "data_tests": {
@@ -491,7 +491,7 @@
       "additionalProperties": false
     },
     "limit": {
-      "type": "number"
+      "type": "integer"
     },
     "location": {
       "type": "string"

--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -60,18 +60,20 @@
         }
       }
     },
-    "data_tests":{
+    "data_tests": {
       "type": "array",
       "description": "Add descriptions to custom singular tests",
       "items": {
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string",
             "description": "The name of the singular test"
           },
-          "description":{
+          "description": {
             "type": "string",
             "description": "A description of the test's purpose, how it is implemented, and perhaps what you should do if it starts failing."
           }
@@ -1360,7 +1362,7 @@
             }
           },
           "additionalProperties": false
-      },
+        },
         "grain_to_date": {
           "enum": [
             "nanosecond",
@@ -1924,7 +1926,7 @@
           "type": "string"
         },
         "offset_to_grain": {
-            "type": "string"
+          "type": "string"
         },
         "offset_window": {
           "type": "string"
@@ -2146,7 +2148,7 @@
           "type": "string"
         },
         "limit": {
-          "type": "number"
+          "type": "integer"
         },
         "schema": {
           "description": "Only relevant when `store_failures` is true",


### PR DESCRIPTION
`limit` and `config-version` types are currently mis-typed in these jsonschemas!

In dbt-core, these are both actually optional integers: 
* limit: https://github.com/dbt-labs/dbt-core/blob/2cde93bf6375ac681b0a3fb934a9e827d4f85039/core/dbt/artifacts/resources/v1/config.py#L179
* config-version: https://github.com/dbt-labs/dbt-core/blob/2cde93bf6375ac681b0a3fb934a9e827d4f85039/core/dbt/contracts/project.py#L215


Note: only modifying 'latest' to avoid mutating schemas pertaining to EOL versions.