### PR TITLE
Add missing +database and database properties to snapshot_configs

### DIFF
--- a/schemas/latest/dbt_project-latest.json
+++ b/schemas/latest/dbt_project-latest.json
@@ -908,6 +908,9 @@
         "+check_cols": {
           "$ref": "#/$defs/string_or_array_of_strings"
         },
+        "+database": {
+          "$ref": "#/$defs/database"
+        },
         "+docs": {
           "$ref": "#/$defs/docs_config"
         },
@@ -964,6 +967,9 @@
         },
         "check_cols": {
           "$ref": "#/$defs/string_or_array_of_strings"
+        },
+        "database": {
+          "$ref": "#/$defs/database"
         },
         "docs": {
           "$ref": "#/$defs/docs_config"


### PR DESCRIPTION
- Adds +database property to snapshot_configs to match model_configs
- Adds database property to snapshot_configs to match model_configs
- Fixes validation error when using +database configuration in snapshots
- Resolves issue where snapshots would show 'Expected null' error for +database

Both prefixed (+database) and non-prefixed (database) variants are now supported in snapshot configurations, making them consistent with model configurations.

Fixes #198 