### PR TITLE
Add BigQuery resource_tags support to JSON schemas

### DIFF
--- a/schemas/latest/dbt_project-latest.json
+++ b/schemas/latest/dbt_project-latest.json
@@ -589,6 +589,9 @@
         "+pre-hook": {
           "$ref": "#/$defs/array_of_strings"
         },
+        "+resource_tags": {
+          "$ref": "#/$defs/resource_tags"
+        },
         "+schema": {
           "$ref": "#/$defs/schema"
         },
@@ -693,6 +696,9 @@
         "pre-hook": {
           "$ref": "#/$defs/array_of_strings"
         },
+        "resource_tags": {
+          "$ref": "#/$defs/resource_tags"
+        },
         "schema": {
           "$ref": "#/$defs/schema"
         },
@@ -760,6 +766,17 @@
       },
       "additionalProperties": false
     },
+    "resource_tags": {
+      "title": "Resource Tags",
+      "description": "BigQuery resource tags for IAM access control. Keys must be in format 'project_id/key_name'.",
+      "type": "object",
+      "patternProperties": {
+        "^[^/]+/[^/]+$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "schema": {
       "type": [
         "null",
@@ -808,6 +825,9 @@
         },
         "+quote_columns": {
           "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "+resource_tags": {
+          "$ref": "#/$defs/resource_tags"
         },
         "+schema": {
           "$ref": "#/$defs/schema"
@@ -859,6 +879,9 @@
         },
         "quote_columns": {
           "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "resource_tags": {
+          "$ref": "#/$defs/resource_tags"
         },
         "schema": {
           "$ref": "#/$defs/schema"
@@ -941,6 +964,9 @@
         "+quote_columns": {
           "$ref": "#/$defs/boolean_or_jinja_string"
         },
+        "+resource_tags": {
+          "$ref": "#/$defs/resource_tags"
+        },
         "+strategy": {
           "$ref": "#/$defs/strategy"
         },
@@ -1000,6 +1026,9 @@
         },
         "quote_columns": {
           "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "resource_tags": {
+          "$ref": "#/$defs/resource_tags"
         },
         "strategy": {
           "$ref": "#/$defs/strategy"

--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -2019,6 +2019,17 @@
             "sync_all_columns"
           ]
         },
+        "resource_tags": {
+          "title": "Resource tags",
+          "description": "Configuration specific to BigQuery adapter used to apply resource tags for IAM access control. Tags must follow the format {google_cloud_project_id}/{key_name}: value.",
+          "type": "object",
+          "patternProperties": {
+            "^[^/]+/[^/]+$": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "snowflake_warehouse": {
           "type": "string"
         },

--- a/tests/latest/valid/dbt_project.yml
+++ b/tests/latest/valid/dbt_project.yml
@@ -8,7 +8,7 @@ name: 'test'
 # This setting configures which "profile" dbt uses for this project.
 profile: 'test'
 
-flags: 
+flags:
   require_explicit_package_overrides_for_builtin_materializations: True
 
 # These configurations specify where dbt should look for different types of files.
@@ -48,7 +48,7 @@ models:
     empty_subdirectory:
     another_one:
       +group: real
-      meta: 
+      meta:
         owner: Tony
     contracted_models:
       +contract:
@@ -63,11 +63,15 @@ models:
       +backup: '{{ target.name == "prod" }}'
       +target_lag: 20 minutes
       +snowflake_warehouse: my_warehouse
-    
+
   test_bq:
     +labels:
       key: val
       jinja_key: "{{ target.name }}"
+    +resource_tags:
+      my-project-id/environment: production
+      my-project-id/data_classification: sensitive
+      another-project/access_level: "{{ env_var('ACCESS_LEVEL', 'restricted') }}"
 
 unit_tests:
   meta:
@@ -76,6 +80,8 @@ unit_tests:
 seeds:
   test:
     +enabled: false
+    +resource_tags:
+      my-project/seed_env: development
     empty_subdirectory:
 
 tests:
@@ -95,7 +101,7 @@ tests:
 snapshots:
   test:
     +target_schema: schema
-    +target_database: database 
+    +target_database: database
     +invalidate_hard_deletes: true
     +grants:
       select: ['role']
@@ -103,7 +109,7 @@ snapshots:
     empty_subdirectory:
 
 sources:
-  test: 
+  test:
     +enabled: true
     empty_subdirectory:
 

--- a/tests/latest/valid/dbt_yml_files.yml
+++ b/tests/latest/valid/dbt_yml_files.yml
@@ -78,6 +78,24 @@ models:
       target_lag: downstream
       snowflake_warehouse: my_warehouse
 
+  - name: my_bigquery_model
+    description: "A dbt model with BigQuery-specific configurations"
+    config:
+      materialized: table
+      labels:
+        environment: production
+        team: analytics
+      resource_tags:
+        my-project-id/environment: production
+        my-project-id/data_classification: sensitive
+        bigquery-project/access_level: "{{ env_var('ACCESS_LEVEL', 'restricted') }}"
+      hours_to_expiration: 72
+      kms_key_name: "projects/my-project/locations/us-central1/keyRings/my-ring/cryptoKeys/my-key"
+    columns:
+      - name: id
+        description: "The primary key"
+        data_type: int
+
 unit_tests:
   - name: my_first_unit_test
     expect:


### PR DESCRIPTION
# Add BigQuery resource_tags support to JSON schemas

Updates dbt JSON schemas to support the new `resource_tags` configuration option added in [dbt-labs/dbt-adapters#1177](https://github.com/dbt-labs/dbt-adapters/pull/1177).

## Changes

- **`dbt_project-latest.json`**: Added `resource_tags` and `+resource_tags` support to `model_configs`, `seed_configs`, and `snapshot_configs`
- **`dbt_yml_files-latest.json`**: Added `resource_tags` support to `model_configs` for YAML file configurations

## Resource Tags Format

- **Pattern**: `{project_id}/{key_name}: value`
- **Validation**: Regex pattern `^[^/]+/[^/]+$`
- **Purpose**: IAM access control and security governance

## Usage Example

```yaml
models:
  my_project:
    +resource_tags:
      my-project-id/environment: production
      my-project-id/team: analytics
```