### PR TITLE
Add latest-fusion JSON schemas

### DIFF
--- a/schemas/latest_fusion/dbt_cloud-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_cloud-latest-fusion.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "required": [
+    "project-id"
+  ],
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "defer-env-id": {
+      "type": "string"
+    },
+    "project-id": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/latest_fusion/dependencies-latest-fusion.json
+++ b/schemas/latest_fusion/dependencies-latest-fusion.json
@@ -1,0 +1,142 @@
+{
+  "title": "dependencies",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "packages": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "required": [
+              "package",
+              "version"
+            ],
+            "properties": {
+              "version": {
+                "title": "Package version",
+                "description": "A semantic version string or range, such as [\">=1.0.0\", \"<2.0.0\"]",
+                "type": [
+                  "array",
+                  "number",
+                  "string"
+                ]
+              },
+              "install-prerelease": {
+                "title": "Install Prerelease",
+                "description": "Opt in to prerelease versions of a package",
+                "type": "boolean"
+              },
+              "package": {
+                "title": "Package identifier",
+                "description": "Must be in format `org_name/package_name`. Refer to hub.getdbt.com for installation instructions",
+                "type": "string",
+                "examples": [
+                  "dbt-labs/dbt_utils"
+                ],
+                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "private"
+            ],
+            "properties": {
+              "private": {
+                "title": "Package identifier",
+                "description": "Must be in format `org_name/package_name`. Refer to docs.getdbt.com for installation instructions",
+                "type": "string",
+                "examples": [
+                  "dbt-labs/private_dbt_utils"
+                ],
+                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
+              },
+              "revision": {
+                "title": "Revision",
+                "description": "Pin your package to a specific release by specifying a release name",
+                "type": "string"
+              },
+              "subdirectory": {
+                "title": "Repo subdirectory",
+                "description": "Subdirectory of the repo where the dbt package is located",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "git"
+            ],
+            "properties": {
+              "git": {
+                "title": "Git URL",
+                "type": "string"
+              },
+              "revision": {
+                "title": "Revision",
+                "description": "Pin your package to a specific release by specifying a release name",
+                "type": "string"
+              },
+              "subdirectory": {
+                "title": "Subdirectory",
+                "description": "Only required if the package is nested in a subdirectory of the git project",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "tarball"
+            ],
+            "properties": {
+              "name": {
+                "description": "dbt will create a subdirectory in your `packages-install-path` with this name, and the tarball's source code will be installed here.",
+                "type": "string"
+              },
+              "tarball": {
+                "title": "Internally-hosted tarball URL",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "local": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "minItems": 1
+    },
+    "projects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/latest_fusion/packages-latest-fusion.json
+++ b/schemas/latest_fusion/packages-latest-fusion.json
@@ -1,0 +1,130 @@
+{
+    "title": "packages",
+    "type": "object",
+    "required": [
+        "packages"
+    ],
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "packages": {
+            "type": "array",
+            "items": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "required": [
+                            "package",
+                            "version"
+                        ],
+                        "properties": {
+                            "version": {
+                                "title": "Package version",
+                                "description": "A semantic version string or range, such as [\">=1.0.0\", \"<2.0.0\"]",
+                                "type": [
+                                    "array",
+                                    "number",
+                                    "string"
+                                ]
+                            },
+                            "install-prerelease": {
+                                "title": "Install Prerelease",
+                                "description": "Opt in to prerelease versions of a package",
+                                "type": "boolean"
+                            },
+                            "package": {
+                                "title": "Package identifier",
+                                "description": "Must be in format `org_name/package_name`. Refer to hub.getdbt.com for installation instructions",
+                                "type": "string",
+                                "examples": [
+                                    "dbt-labs/dbt_utils"
+                                ],
+                                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "required": [
+                            "private"
+                        ],
+                        "properties": {
+                            "private": {
+                                "title": "Package identifier",
+                                "description": "Must be in format `org_name/package_name`. Refer to docs.getdbt.com for installation instructions",
+                                "type": "string",
+                                "examples": [
+                                    "dbt-labs/private_dbt_utils"
+                                ],
+                                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
+                            },
+                            "revision": {
+                                "title": "Revision",
+                                "description": "Pin your package to a specific release by specifying a release name",
+                                "type": "string"
+                            },
+                            "subdirectory": {
+                                "title": "Repo subdirectory",
+                                "description": "Subdirectory of the repo where the dbt package is located",
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "required": [
+                            "git"
+                        ],
+                        "properties": {
+                            "git": {
+                                "title": "Git URL",
+                                "type": "string"
+                            },
+                            "revision": {
+                                "title": "Revision",
+                                "description": "Pin your package to a specific release by specifying a release name",
+                                "type": "string"
+                            },
+                            "subdirectory": {
+                                "title": "Subdirectory",
+                                "description": "Only required if the package is nested in a subdirectory of the git project",
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "required": [
+                            "name",
+                            "tarball"
+                        ],
+                        "properties": {
+                            "name": {
+                                "description": "dbt will create a subdirectory in your `packages-install-path` with this name, and the tarball's source code will be installed here.",
+                                "type": "string"
+                            },
+                            "tarball": {
+                                "title": "Internally-hosted tarball URL",
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "local": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                ]
+            },
+            "minItems": 1
+        }
+    },
+    "additionalProperties": false
+}

--- a/schemas/latest_fusion/selectors-latest-fusion.json
+++ b/schemas/latest_fusion/selectors-latest-fusion.json
@@ -1,0 +1,157 @@
+{
+  "title": "selectors",
+  "type": "object",
+  "required": [
+    "selectors"
+  ],
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "selectors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "default": {
+            "oneOf": [
+              {
+                "type": "string",
+                "pattern": "\\{\\{.*\\}\\}"
+              },
+              {
+                "type": "boolean"
+              }
+            ],
+            "additionalProperties": false
+          },
+          "definition": {
+            "oneOf": [
+              {
+                "$ref": "#/$defs/definition_block"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/union_block"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "boolean_or_jinja_string": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/jinja_string"
+        },
+        {
+          "type": "boolean"
+        }
+      ],
+      "additionalProperties": false
+    },
+    "definition_block": {
+      "type": "object",
+      "properties": {
+        "children": {
+          "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "children_depth": {
+          "type": "number"
+        },
+        "childrens_parents": {
+          "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "indirect_selection": {
+          "type": "string",
+          "enum": [
+            "buildable",
+            "cautious",
+            "eager"
+          ]
+        },
+        "method": {
+          "type": "string",
+          "enum": [
+            "config",
+            "exposure",
+            "file",
+            "fqn",
+            "group",
+            "metric",
+            "package",
+            "path",
+            "result",
+            "source",
+            "source_status",
+            "state",
+            "tag",
+            "test_name",
+            "test_type",
+            "wildcard"
+          ]
+        },
+        "parents": {
+          "$ref": "#/$defs/boolean_or_jinja_string"
+        },
+        "parents_depth": {
+          "type": "number"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "exclude_block": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/intersection_block"
+          },
+          {
+            "$ref": "#/$defs/definition_block"
+          }
+        ]
+      }
+    },
+    "intersection_block": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/definition_block"
+      }
+    },
+    "jinja_string": {
+      "type": "string",
+      "pattern": "\\{\\{.*\\}\\}"
+    },
+    "union_block": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/intersection_block"
+          },
+          {
+            "$ref": "#/$defs/definition_block"
+          },
+          {
+            "$ref": "#/$defs/exclude_block"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Copies JSON schema definitions from schemas/latest/ to schemas/latest_fusion/ to support the latest-fusion dbt configuration format.

Changes:
- Added dbt_cloud-latest-fusion.json
- Added dependencies-latest-fusion.json
- Added packages-latest-fusion.json
- Added selectors-latest-fusion.json

All schemas were copied from their corresponding files in the schemas/latest/ directory.