### PR TITLE
Add the config field to metrics

### DIFF
--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -373,6 +373,17 @@
           },
           "type_params": {
             "type": "object"
+          },
+          "config": {
+            "type": "object",
+            "properties": {
+              "meta": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
the [config field](https://docs.getdbt.com/docs/build/metrics-overview) is missing from the metrics items