### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/schemas/latest_fusion/dbt_project-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_project-latest-fusion.json
@@ -1833,6 +1833,16 @@
             "null"
           ]
         },
+        "+packages": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "+quoting": {
           "anyOf": [
             {
@@ -5438,8 +5448,8 @@
     "Severity": {
       "type": "string",
       "enum": [
-        "Error",
-        "Warn"
+        "error",
+        "warn"
       ]
     },
     "SnapshotMetaColumnNames": {

--- a/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
@@ -2623,6 +2623,16 @@
             "null"
           ]
         },
+        "packages": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "partition_by": {
           "anyOf": [
             {
@@ -6050,8 +6060,8 @@
     "Severity": {
       "type": "string",
       "enum": [
-        "Error",
-        "Warn"
+        "error",
+        "warn"
       ]
     },
     "SnapshotConfig": {


### PR DESCRIPTION
## Summary

This PR syncs the latest fusion JSON schemas from the dbt-fusion repository.

### Files Updated
- `schemas/latest_fusion/dbt_project-latest-fusion.json`
- `schemas/latest_fusion/dbt_yml_files-latest-fusion.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Ref**: main
- **Commit**: [`ac9c40c7dcfaec189611a3c8a89c35f3dc4a08bc`](https://github.com/dbt-labs/fs/commit/ac9c40c7dcfaec189611a3c8a89c35f3dc4a08bc)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/24095302210)