### PR TITLE
fix(packages.json): support provider key and multi-path gitlab refs

### DIFF
--- a/schemas/latest/packages-latest.json
+++ b/schemas/latest/packages-latest.json
@@ -51,12 +51,27 @@
                         "properties": {
                             "private": {
                                 "title": "Package identifier",
-                                "description": "Must be in format `org_name/package_name`. Refer to docs.getdbt.com for installation instructions",
+                                "description": "Must be in format `org_name/package_name` or `host/group/project` for GitLab. Refer to docs.getdbt.com for installation instructions",
                                 "type": "string",
                                 "examples": [
-                                    "dbt-labs/private_dbt_utils"
+                                    "dbt-labs/private_dbt_utils",
+                                    "getdbt.com/group/project"
                                 ],
-                                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
+                                "pattern": "^[\\w\\-\\.]+(/[\\w\\-\\.]+)+$"
+                            },
+                            "provider": {
+                                "title": "Provider",
+                                "description": "Authentication provider configuration for the private package",
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "title": "Provider type",
+                                        "description": "The authentication provider for the private package",
+                                        "type": "string",
+                                        "enum": ["github", "gitlab", "azure_devops"]
+                                    }
+                                },
+                                "additionalProperties": true
                             },
                             "revision": {
                                 "title": "Revision",

--- a/schemas/latest_fusion/packages-latest-fusion.json
+++ b/schemas/latest_fusion/packages-latest-fusion.json
@@ -51,12 +51,27 @@
                         "properties": {
                             "private": {
                                 "title": "Package identifier",
-                                "description": "Must be in format `org_name/package_name`. Refer to docs.getdbt.com for installation instructions",
+                                "description": "Must be in format `org_name/package_name` or `host/group/project` for GitLab. Refer to docs.getdbt.com for installation instructions",
                                 "type": "string",
                                 "examples": [
-                                    "dbt-labs/private_dbt_utils"
+                                    "dbt-labs/private_dbt_utils",
+                                    "getdbt.com/group/project"
                                 ],
-                                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
+                                "pattern": "^[\\w\\-\\.]+(/[\\w\\-\\.]+)+$"
+                            },
+                            "provider": {
+                                "title": "Provider",
+                                "description": "Authentication provider configuration for the private package",
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "title": "Provider type",
+                                        "description": "The authentication provider for the private package",
+                                        "type": "string",
+                                        "enum": ["github", "gitlab", "azure_devops"]
+                                    }
+                                },
+                                "additionalProperties": true
                             },
                             "revision": {
                                 "title": "Revision",


### PR DESCRIPTION
## Fix private package schema: support `provider` key and multi-segment repo paths

Closes #237 

  ### Problem

  Two issues caused false linting errors for valid private package configurations in the dbt Cloud IDE:

  1. **Missing `provider` key** — The `private` package object had `additionalProperties: false` but no `provider`
  property defined. Any package using the `provider` authentication config (required for GitHub, GitLab, and Azure DevOps
   private packages) would fail schema validation.

  2. **Regex too restrictive for GitLab paths** — The path pattern `^[\w\-\.]+/[\w\-\.]+$` only allowed a single `/`,
  which rejected GitLab repo paths that include a host or nested groups (e.g. `getdbt.com/group/project`).

  ### Changes

  - **`provider` property added** to the `private` package object in both `packages-latest.json` and
  `packages-latest-fusion.json`. The `provider.type` field is constrained to the three supported values: `github`,
  `gitlab`, `azure_devops`. Other provider-specific fields (tokens, etc.) are allowed via `additionalProperties: true`.

  - **Regex updated** from `^[\w\-\.]+/[\w\-\.]+$` → `^[\w\-\.]+(/[\w\-\.]+)+$`, allowing one or more `/`-separated path
  segments while still requiring at least one.