### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/schemas/latest_fusion/dbt_project-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_project-latest-fusion.json
@@ -1489,6 +1489,12 @@
             "null"
           ]
         },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -2757,6 +2763,12 @@
             "null"
           ]
         },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -3460,6 +3472,12 @@
             "null"
           ]
         },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -4141,6 +4159,12 @@
             }
           ]
         },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -4728,6 +4752,12 @@
             "null"
           ]
         },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -5229,6 +5259,12 @@
           "default": null,
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "+snowflake_initialization_warehouse": {
+          "type": [
+            "string",
             "null"
           ]
         },

--- a/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
@@ -1327,6 +1327,12 @@
             "null"
           ]
         },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "snowflake_warehouse": {
           "type": [
             "string",
@@ -2759,6 +2765,12 @@
         "skip_not_matched_step": {
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
             "null"
           ]
         },
@@ -4446,6 +4458,12 @@
             "null"
           ]
         },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "snowflake_warehouse": {
           "type": [
             "string",
@@ -5871,6 +5889,12 @@
             "null"
           ]
         },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "snowflake_warehouse": {
           "type": [
             "string",
@@ -6665,6 +6689,12 @@
             }
           ]
         },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "snowflake_warehouse": {
           "type": [
             "string",
@@ -7415,6 +7445,12 @@
         "skip_not_matched_step": {
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
             "null"
           ]
         },
@@ -8313,6 +8349,12 @@
         "skip_not_matched_step": {
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "snowflake_initialization_warehouse": {
+          "type": [
+            "string",
             "null"
           ]
         },


### PR DESCRIPTION
## Summary

This PR syncs the latest fusion JSON schemas from the dbt-fusion repository.

### Files Updated
- `schemas/latest_fusion/dbt_project-latest-fusion.json`
- `schemas/latest_fusion/dbt_yml_files-latest-fusion.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Ref**: release/v2.0.0-preview.172
- **Commit**: [`42eeefd523a9a40f6c7a84112d1d28c740a1e227`](https://github.com/dbt-labs/fs/commit/42eeefd523a9a40f6c7a84112d1d28c740a1e227)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/24377126794)