### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/schemas/latest_fusion/dbt_project-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_project-latest-fusion.json
@@ -1246,6 +1246,12 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "+immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+include_full_name_in_path": {
           "default": null,
           "type": [
@@ -2318,6 +2324,12 @@
             "null"
           ]
         },
+        "+immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+imports": {
           "anyOf": [
             {
@@ -3220,6 +3232,12 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "+immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+include_full_name_in_path": {
           "type": [
             "boolean",
@@ -3868,6 +3886,12 @@
           ],
           "format": "uint64",
           "minimum": 0.0
+        },
+        "+immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "+include_full_name_in_path": {
           "default": null,
@@ -4752,12 +4776,6 @@
             "null"
           ]
         },
-        "+snowflake_initialization_warehouse": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "+snowflake_warehouse": {
           "type": [
             "string",
@@ -5051,6 +5069,12 @@
           ],
           "format": "uint64",
           "minimum": 0.0
+        },
+        "+immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "+include_full_name_in_path": {
           "default": null,

--- a/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
@@ -1047,6 +1047,12 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "include_full_name_in_path": {
           "type": [
             "boolean",
@@ -2492,6 +2498,12 @@
           ],
           "format": "uint64",
           "minimum": 0.0
+        },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "include_full_name_in_path": {
           "type": [
@@ -4019,6 +4031,12 @@
           "minimum": 0.0
         },
         "http_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "immutable_where": {
           "type": [
             "string",
             "null"
@@ -5589,6 +5607,12 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "include_full_name_in_path": {
           "type": [
             "boolean",
@@ -6371,6 +6395,12 @@
           ],
           "format": "uint64",
           "minimum": 0.0
+        },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "include_full_name_in_path": {
           "type": [
@@ -7177,6 +7207,12 @@
           ],
           "format": "uint64",
           "minimum": 0.0
+        },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "include_full_name_in_path": {
           "type": [
@@ -8114,6 +8150,12 @@
           ],
           "format": "uint64",
           "minimum": 0.0
+        },
+        "immutable_where": {
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "include_full_name_in_path": {
           "type": [


### PR DESCRIPTION
## Summary

This PR syncs the latest fusion JSON schemas from the dbt-fusion repository.

### Files Updated
- `schemas/latest_fusion/dbt_project-latest-fusion.json`
- `schemas/latest_fusion/dbt_yml_files-latest-fusion.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Ref**: release/v2.0.0-preview.173
- **Commit**: [`ea511a4e8add4cf3a61a24a859fb72e96530c753`](https://github.com/dbt-labs/fs/commit/ea511a4e8add4cf3a61a24a859fb72e96530c753)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/24492481835)