### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/schemas/latest_fusion/dbt_cloud-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_cloud-latest-fusion.json
@@ -1,16 +1,88 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DbtCloudConfig",
+  "description": "Represents the top-level dbt Cloud configuration file",
   "type": "object",
   "required": [
-    "project-id"
+    "context",
+    "projects",
+    "version"
   ],
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
-    "defer-env-id": {
-      "type": "string"
+    "context": {
+      "$ref": "#/definitions/DbtCloudContext"
     },
-    "project-id": {
+    "projects": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DbtCloudProject"
+      }
+    },
+    "version": {
       "type": "string"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "definitions": {
+    "DbtCloudContext": {
+      "description": "Represents the context section of the dbt Cloud configuration",
+      "type": "object",
+      "required": [
+        "active-host",
+        "active-project"
+      ],
+      "properties": {
+        "active-host": {
+          "type": "string"
+        },
+        "active-project": {
+          "type": "string"
+        },
+        "defer-env-id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DbtCloudProject": {
+      "description": "Represents a dbt Cloud project configuration",
+      "type": "object",
+      "required": [
+        "account-host",
+        "account-id",
+        "account-name",
+        "project-id",
+        "project-name",
+        "token-name",
+        "token-value"
+      ],
+      "properties": {
+        "account-host": {
+          "type": "string"
+        },
+        "account-id": {
+          "type": "string"
+        },
+        "account-name": {
+          "type": "string"
+        },
+        "project-id": {
+          "type": "string"
+        },
+        "project-name": {
+          "type": "string"
+        },
+        "token-name": {
+          "type": "string"
+        },
+        "token-value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/schemas/latest_fusion/dbt_project-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_project-latest-fusion.json
@@ -702,6 +702,7 @@
       "type": "object",
       "properties": {
         "count": {
+          "default": null,
           "type": [
             "integer",
             "null"
@@ -709,6 +710,7 @@
           "format": "int64"
         },
         "period": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessPeriod"
@@ -881,6 +883,13 @@
         "continue",
         "fail",
         "unknown"
+      ]
+    },
+    "OnError": {
+      "type": "string",
+      "enum": [
+        "skip_children",
+        "continue"
       ]
     },
     "OnSchemaChange": {
@@ -1456,6 +1465,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "+scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+schema": {
@@ -2103,6 +2118,13 @@
             }
           ]
         },
+        "+change_tracking": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "+cluster_by": {
           "anyOf": [
             {
@@ -2174,6 +2196,15 @@
             "boolean",
             "null"
           ]
+        },
+        "+data_retention_time_in_days": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "+database": {
           "type": [
@@ -2323,6 +2354,15 @@
             "string",
             "null"
           ]
+        },
+        "+iceberg_version": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "+immutable_where": {
           "type": [
@@ -2483,6 +2523,15 @@
             }
           ]
         },
+        "+max_data_extension_time_in_days": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "+max_staleness": {
           "type": [
             "string",
@@ -2556,6 +2605,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/OnConfigurationChange"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "+on_error": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OnError"
             },
             {
               "type": "null"
@@ -2738,6 +2797,12 @@
             }
           ]
         },
+        "+scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+schema": {
           "type": [
             "string",
@@ -2825,6 +2890,18 @@
             }
           ]
         },
+        "+storage_serialization_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+submission_method": {
           "type": [
             "string",
@@ -2865,6 +2942,12 @@
           "$ref": "#/definitions/StringOrArrayOfStrings"
         },
         "+target_alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+target_file_size": {
           "type": [
             "string",
             "null"
@@ -2918,6 +3001,13 @@
         },
         "+use_anonymous_sproc": {
           "description": "Snowflake Python model config: use anonymous stored procedure (default: true)",
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "+use_uniform": {
           "default": null,
           "type": [
             "boolean",
@@ -3464,6 +3554,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "+scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+schema": {
@@ -4146,6 +4242,12 @@
             }
           ]
         },
+        "+scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+schema": {
           "type": [
             "string",
@@ -4337,15 +4439,6 @@
     "ProjectSourceConfig": {
       "type": "object",
       "properties": {
-        "+adapter_properties": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "$ref": "#/definitions/AnyValue"
-          }
-        },
         "+as_columnstore": {
           "default": null,
           "type": [
@@ -4367,29 +4460,10 @@
             "null"
           ]
         },
-        "+automatic_clustering": {
-          "default": null,
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "+backup": {
           "default": null,
           "type": [
             "boolean",
-            "null"
-          ]
-        },
-        "+base_location_root": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "+base_location_subpath": {
-          "type": [
-            "string",
             "null"
           ]
         },
@@ -4445,13 +4519,6 @@
             "null"
           ]
         },
-        "+copy_grants": {
-          "default": null,
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "+databricks_compute": {
           "type": [
             "string",
@@ -4488,12 +4555,6 @@
           ]
         },
         "+event_time": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "+external_volume": {
           "type": [
             "string",
             "null"
@@ -4546,12 +4607,6 @@
             {
               "$ref": "#/definitions/IndexesConfig"
             }
-          ]
-        },
-        "+initialize": {
-          "type": [
-            "string",
-            "null"
           ]
         },
         "+job_execution_timeout_seconds": {
@@ -4687,16 +4742,6 @@
             "type": "string"
           }
         },
-        "+query_tag": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/QueryTag"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "+quoting": {
           "anyOf": [
             {
@@ -4715,22 +4760,10 @@
           ],
           "format": "double"
         },
-        "+refresh_mode": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "+require_partition_filter": {
           "default": null,
           "type": [
             "boolean",
-            "null"
-          ]
-        },
-        "+row_access_policy": {
-          "type": [
-            "string",
             "null"
           ]
         },
@@ -4755,13 +4788,6 @@
             }
           ]
         },
-        "+secure": {
-          "default": null,
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "+skip_matched_step": {
           "default": null,
           "type": [
@@ -4773,12 +4799,6 @@
           "default": null,
           "type": [
             "boolean",
-            "null"
-          ]
-        },
-        "+snowflake_warehouse": {
-          "type": [
-            "string",
             "null"
           ]
         },
@@ -4825,12 +4845,6 @@
             }
           ]
         },
-        "+table_tag": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "+table_type": {
           "default": null,
           "type": [
@@ -4854,12 +4868,6 @@
             "null"
           ]
         },
-        "+target_lag": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "+tblproperties": {
           "type": [
             "object",
@@ -4868,19 +4876,6 @@
           "additionalProperties": {
             "$ref": "#/definitions/AnyValue"
           }
-        },
-        "+tmp_relation_type": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "+transient": {
-          "default": null,
-          "type": [
-            "boolean",
-            "null"
-          ]
         }
       },
       "additionalProperties": {
@@ -5263,6 +5258,12 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "+scheduler": {
+          "type": [
+            "string",
+            "null"
           ]
         },
         "+secure": {

--- a/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
@@ -903,6 +903,12 @@
             }
           ]
         },
+        "change_tracking": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "cluster_by": {
           "anyOf": [
             {
@@ -934,6 +940,14 @@
             "boolean",
             "null"
           ]
+        },
+        "data_retention_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "database": {
           "type": [
@@ -1047,6 +1061,14 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "iceberg_version": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -1152,6 +1174,14 @@
               "type": "null"
             }
           ]
+        },
+        "max_data_extension_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "max_staleness": {
           "type": [
@@ -1299,6 +1329,12 @@
             }
           ]
         },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "schema": {
           "type": [
             "string",
@@ -1383,6 +1419,18 @@
             }
           ]
         },
+        "storage_serialization_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "store_failures": {
           "default": null,
           "type": [
@@ -1429,6 +1477,12 @@
             "null"
           ]
         },
+        "target_file_size": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "target_lag": {
           "type": [
             "string",
@@ -1459,6 +1513,12 @@
           ]
         },
         "transient": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "use_uniform": {
           "type": [
             "boolean",
             "null"
@@ -2195,6 +2255,7 @@
       "type": "object",
       "properties": {
         "count": {
+          "default": null,
           "type": [
             "integer",
             "null"
@@ -2202,6 +2263,7 @@
           "format": "int64"
         },
         "period": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessPeriod"
@@ -2356,6 +2418,12 @@
             }
           ]
         },
+        "change_tracking": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "cluster_by": {
           "anyOf": [
             {
@@ -2387,6 +2455,14 @@
             "boolean",
             "null"
           ]
+        },
+        "data_retention_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "database": {
           "type": [
@@ -2499,6 +2575,14 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "iceberg_version": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -2587,6 +2671,14 @@
             "string",
             "null"
           ]
+        },
+        "max_data_extension_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "max_staleness": {
           "type": [
@@ -2756,6 +2848,12 @@
             }
           ]
         },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "schema": {
           "type": [
             "string",
@@ -2824,6 +2922,18 @@
             }
           ]
         },
+        "storage_serialization_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "table_tag": {
           "type": [
             "string",
@@ -2847,6 +2957,12 @@
           ]
         },
         "target_alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target_file_size": {
           "type": [
             "string",
             "null"
@@ -2898,6 +3014,12 @@
             }
           ]
         },
+        "use_uniform": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "volatility": {
           "anyOf": [
             {
@@ -2919,6 +3041,44 @@
         "aggregate",
         "table"
       ]
+    },
+    "FunctionOverload": {
+      "description": "An overload of a function with different argument signatures. Each overload references a separate SQL file (via `defined_in`) that contains the function body for this overload.",
+      "type": "object",
+      "required": [
+        "defined_in"
+      ],
+      "properties": {
+        "arguments": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/FunctionArgument"
+          }
+        },
+        "defined_in": {
+          "type": "string"
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "returns": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FunctionReturnType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "FunctionProperties": {
       "type": "object",
@@ -2975,6 +3135,15 @@
         },
         "name": {
           "type": "string"
+        },
+        "overloads": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/FunctionOverload"
+          }
         },
         "returns": {
           "anyOf": [
@@ -3821,6 +3990,12 @@
             }
           ]
         },
+        "change_tracking": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "cluster_by": {
           "anyOf": [
             {
@@ -3890,6 +4065,14 @@
             "boolean",
             "null"
           ]
+        },
+        "data_retention_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "database": {
           "type": [
@@ -4035,6 +4218,14 @@
             "string",
             "null"
           ]
+        },
+        "iceberg_version": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "immutable_where": {
           "type": [
@@ -4192,6 +4383,14 @@
             }
           ]
         },
+        "max_data_extension_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "max_staleness": {
           "type": [
             "string",
@@ -4264,6 +4463,16 @@
           "anyOf": [
             {
               "$ref": "#/definitions/OnConfigurationChange"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "on_error": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OnError"
             },
             {
               "type": "null"
@@ -4443,6 +4652,12 @@
             }
           ]
         },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "schema": {
           "type": [
             "string",
@@ -4526,6 +4741,18 @@
             }
           ]
         },
+        "storage_serialization_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "submission_method": {
           "type": [
             "string",
@@ -4578,6 +4805,12 @@
             "null"
           ]
         },
+        "target_file_size": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "target_lag": {
           "type": [
             "string",
@@ -4625,6 +4858,12 @@
         },
         "use_anonymous_sproc": {
           "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "use_uniform": {
           "type": [
             "boolean",
             "null"
@@ -4971,6 +5210,13 @@
         "continue",
         "fail",
         "unknown"
+      ]
+    },
+    "OnError": {
+      "type": "string",
+      "enum": [
+        "skip_children",
+        "continue"
       ]
     },
     "OnSchemaChange": {
@@ -5437,6 +5683,12 @@
             }
           ]
         },
+        "change_tracking": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "cluster_by": {
           "anyOf": [
             {
@@ -5477,6 +5729,14 @@
             "boolean",
             "null"
           ]
+        },
+        "data_retention_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "database": {
           "type": [
@@ -5607,6 +5867,14 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "iceberg_version": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -5705,6 +5973,14 @@
               "type": "null"
             }
           ]
+        },
+        "max_data_extension_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "max_staleness": {
           "type": [
@@ -5889,6 +6165,12 @@
             }
           ]
         },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "schema": {
           "type": [
             "string",
@@ -5957,6 +6239,18 @@
             }
           ]
         },
+        "storage_serialization_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "table_tag": {
           "type": [
             "string",
@@ -5981,6 +6275,12 @@
           ]
         },
         "target_alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target_file_size": {
           "type": [
             "string",
             "null"
@@ -6016,6 +6316,12 @@
           ]
         },
         "transient": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "use_uniform": {
           "type": [
             "boolean",
             "null"
@@ -6214,6 +6520,12 @@
             }
           ]
         },
+        "change_tracking": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "check_cols": {
           "anyOf": [
             {
@@ -6255,6 +6567,14 @@
             "boolean",
             "null"
           ]
+        },
+        "data_retention_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "database": {
           "type": [
@@ -6396,6 +6716,14 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "iceberg_version": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "immutable_where": {
           "type": [
             "string",
@@ -6501,6 +6829,14 @@
               "type": "null"
             }
           ]
+        },
+        "max_data_extension_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "max_staleness": {
           "type": [
@@ -6685,6 +7021,12 @@
             }
           ]
         },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "schema": {
           "type": [
             "string",
@@ -6763,6 +7105,18 @@
             }
           ]
         },
+        "storage_serialization_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "strategy": {
           "type": [
             "string",
@@ -6810,6 +7164,12 @@
           ]
         },
         "target_database": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target_file_size": {
           "type": [
             "string",
             "null"
@@ -6869,6 +7229,12 @@
         "updated_at": {
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "use_uniform": {
+          "type": [
+            "boolean",
             "null"
           ]
         }
@@ -7079,6 +7445,12 @@
             }
           ]
         },
+        "change_tracking": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "cluster_by": {
           "anyOf": [
             {
@@ -7110,6 +7482,14 @@
             "boolean",
             "null"
           ]
+        },
+        "data_retention_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "databricks_compute": {
           "type": [
@@ -7201,6 +7581,14 @@
           }
         },
         "hours_to_expiration": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "iceberg_version": {
           "type": [
             "integer",
             "null"
@@ -7308,6 +7696,14 @@
             "string",
             "null"
           ]
+        },
+        "max_data_extension_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "max_staleness": {
           "type": [
@@ -7455,6 +7851,12 @@
             }
           ]
         },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "schema_origin": {
           "description": "Specifies where the schema metadata originates: 'remote' (default) or 'local'",
           "anyOf": [
@@ -7528,6 +7930,18 @@
             }
           ]
         },
+        "storage_serialization_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "sync": {
           "description": "Schema synchronization configuration",
           "anyOf": [
@@ -7568,6 +7982,12 @@
             "null"
           ]
         },
+        "target_file_size": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "target_lag": {
           "type": [
             "string",
@@ -7598,6 +8018,12 @@
           ]
         },
         "transient": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "use_uniform": {
           "type": [
             "boolean",
             "null"
@@ -8039,6 +8465,12 @@
             }
           ]
         },
+        "change_tracking": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "cluster_by": {
           "anyOf": [
             {
@@ -8070,6 +8502,14 @@
             "boolean",
             "null"
           ]
+        },
+        "data_retention_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "databricks_compute": {
           "type": [
@@ -8144,6 +8584,14 @@
           }
         },
         "hours_to_expiration": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "iceberg_version": {
           "type": [
             "integer",
             "null"
@@ -8239,6 +8687,14 @@
             "string",
             "null"
           ]
+        },
+        "max_data_extension_time_in_days": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
         },
         "max_staleness": {
           "type": [
@@ -8376,6 +8832,12 @@
             }
           ]
         },
+        "scheduler": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "secure": {
           "type": [
             "boolean",
@@ -8438,6 +8900,18 @@
             }
           ]
         },
+        "storage_serialization_policy": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "storage_uri": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "table_tag": {
           "type": [
             "string",
@@ -8461,6 +8935,12 @@
           ]
         },
         "target_alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target_file_size": {
           "type": [
             "string",
             "null"
@@ -8496,6 +8976,12 @@
           ]
         },
         "transient": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "use_uniform": {
           "type": [
             "boolean",
             "null"
@@ -8626,6 +9112,12 @@
         "v"
       ],
       "properties": {
+        "access": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "config": {
           "anyOf": [
             {
@@ -8636,11 +9128,50 @@
             }
           ]
         },
+        "constraints": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ModelConstraint"
+          }
+        },
+        "data_tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        },
+        "defined_in": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "deprecation_date": {
           "type": [
             "string",
             "null"
           ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
         },
         "v": {
           "$ref": "#/definitions/AnyValue"

--- a/schemas/latest_fusion/dependencies-latest-fusion.json
+++ b/schemas/latest_fusion/dependencies-latest-fusion.json
@@ -1,142 +1,205 @@
 {
-  "title": "dependencies",
-  "type": "object",
   "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DbtPackages",
+  "type": "object",
   "properties": {
     "packages": {
+      "default": [],
       "type": "array",
       "items": {
-        "anyOf": [
-          {
-            "type": "object",
-            "required": [
-              "package",
-              "version"
-            ],
-            "properties": {
-              "version": {
-                "title": "Package version",
-                "description": "A semantic version string or range, such as [\">=1.0.0\", \"<2.0.0\"]",
-                "type": [
-                  "array",
-                  "number",
-                  "string"
-                ]
-              },
-              "install-prerelease": {
-                "title": "Install Prerelease",
-                "description": "Opt in to prerelease versions of a package",
-                "type": "boolean"
-              },
-              "package": {
-                "title": "Package identifier",
-                "description": "Must be in format `org_name/package_name`. Refer to hub.getdbt.com for installation instructions",
-                "type": "string",
-                "examples": [
-                  "dbt-labs/dbt_utils"
-                ],
-                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "private"
-            ],
-            "properties": {
-              "private": {
-                "title": "Package identifier",
-                "description": "Must be in format `org_name/package_name`. Refer to docs.getdbt.com for installation instructions",
-                "type": "string",
-                "examples": [
-                  "dbt-labs/private_dbt_utils"
-                ],
-                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
-              },
-              "revision": {
-                "title": "Revision",
-                "description": "Pin your package to a specific release by specifying a release name",
-                "type": "string"
-              },
-              "subdirectory": {
-                "title": "Repo subdirectory",
-                "description": "Subdirectory of the repo where the dbt package is located",
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "git"
-            ],
-            "properties": {
-              "git": {
-                "title": "Git URL",
-                "type": "string"
-              },
-              "revision": {
-                "title": "Revision",
-                "description": "Pin your package to a specific release by specifying a release name",
-                "type": "string"
-              },
-              "subdirectory": {
-                "title": "Subdirectory",
-                "description": "Only required if the package is nested in a subdirectory of the git project",
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "name",
-              "tarball"
-            ],
-            "properties": {
-              "name": {
-                "description": "dbt will create a subdirectory in your `packages-install-path` with this name, and the tarball's source code will be installed here.",
-                "type": "string"
-              },
-              "tarball": {
-                "title": "Internally-hosted tarball URL",
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "properties": {
-              "local": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        ]
-      },
-      "minItems": 1
+        "$ref": "#/definitions/DbtPackageEntry"
+      }
     },
     "projects": {
+      "default": [],
       "type": "array",
       "items": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
+        "$ref": "#/definitions/UpstreamProject"
       }
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "definitions": {
+    "DbtPackageEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/HubPackage"
+        },
+        {
+          "$ref": "#/definitions/GitPackage"
+        },
+        {
+          "$ref": "#/definitions/LocalPackage"
+        },
+        {
+          "$ref": "#/definitions/PrivatePackage"
+        },
+        {
+          "$ref": "#/definitions/TarballPackage"
+        }
+      ]
+    },
+    "GitPackage": {
+      "type": "object",
+      "required": [
+        "git"
+      ],
+      "properties": {
+        "git": {
+          "description": "Git clone URL of the package repository (e.g. `https://github.com/dbt-labs/dbt_utils.git`).",
+          "type": "string"
+        },
+        "revision": {
+          "description": "Revision to check out: a tag, branch, or commit SHA.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "subdirectory": {
+          "description": "Subdirectory of the repo where the dbt package is located.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "warn-unpinned": {
+          "description": "Suppress the warning emitted when `revision` is unpinned (i.e. a branch name like `main`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "HubPackage": {
+      "type": "object",
+      "required": [
+        "package"
+      ],
+      "properties": {
+        "install-prerelease": {
+          "description": "Allow installation of pre-release versions when resolving `version`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "package": {
+          "description": "Package identifier on the dbt package hub, in `org/name` form (e.g. `dbt-labs/dbt_utils`).",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version pin. Accepts a single version string, a list of constraints (e.g. `[\">=1.0.0\", \"<2.0.0\"]`), or a number.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PackageVersion"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LocalPackage": {
+      "type": "object",
+      "required": [
+        "local"
+      ],
+      "properties": {
+        "local": {
+          "description": "Filesystem path to the local dbt package, relative to the project root.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PackageVersion": {
+      "anyOf": [
+        {
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "PrivatePackage": {
+      "type": "object",
+      "required": [
+        "private"
+      ],
+      "properties": {
+        "private": {
+          "description": "Private package identifier. Two-segment `org/repo` for GitHub or 2-part Azure DevOps (`azure_active_directory`); three-or-more-segment `org/group/repo` for GitLab subgroups or Azure DevOps `org/project/repo` (`ado` / `azure_devops`).",
+          "type": "string",
+          "pattern": "^[\\w\\-\\.]+(/[\\w\\-\\.]+){1,}$"
+        },
+        "provider": {
+          "description": "Git provider. One of `github` (default), `gitlab`, `ado`, `azure_devops`, or `azure_active_directory`. `ado` / `azure_devops` require an `org/project/repo` path; `azure_active_directory` is hosted-only and uses `org/repo`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "revision": {
+          "description": "Revision to check out: a tag, branch, or commit SHA.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "subdirectory": {
+          "description": "Subdirectory of the repo where the dbt package is located.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "warn-unpinned": {
+          "description": "Suppress the warning emitted when `revision` is unpinned (i.e. a branch name like `main`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TarballPackage": {
+      "type": "object",
+      "required": [
+        "tarball"
+      ],
+      "properties": {
+        "tarball": {
+          "description": "HTTPS URL of a `.tar.gz` archive containing the dbt package.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "UpstreamProject": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/schemas/latest_fusion/packages-latest-fusion.json
+++ b/schemas/latest_fusion/packages-latest-fusion.json
@@ -1,130 +1,205 @@
 {
-    "title": "packages",
-    "type": "object",
-    "required": [
-        "packages"
-    ],
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {
-        "packages": {
-            "type": "array",
-            "items": {
-                "anyOf": [
-                    {
-                        "type": "object",
-                        "required": [
-                            "package",
-                            "version"
-                        ],
-                        "properties": {
-                            "version": {
-                                "title": "Package version",
-                                "description": "A semantic version string or range, such as [\">=1.0.0\", \"<2.0.0\"]",
-                                "type": [
-                                    "array",
-                                    "number",
-                                    "string"
-                                ]
-                            },
-                            "install-prerelease": {
-                                "title": "Install Prerelease",
-                                "description": "Opt in to prerelease versions of a package",
-                                "type": "boolean"
-                            },
-                            "package": {
-                                "title": "Package identifier",
-                                "description": "Must be in format `org_name/package_name`. Refer to hub.getdbt.com for installation instructions",
-                                "type": "string",
-                                "examples": [
-                                    "dbt-labs/dbt_utils"
-                                ],
-                                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
-                            }
-                        },
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "private"
-                        ],
-                        "properties": {
-                            "private": {
-                                "title": "Package identifier",
-                                "description": "Must be in format `org_name/package_name`. Refer to docs.getdbt.com for installation instructions",
-                                "type": "string",
-                                "examples": [
-                                    "dbt-labs/private_dbt_utils"
-                                ],
-                                "pattern": "^[\\w\\-\\.]+/[\\w\\-\\.]+$"
-                            },
-                            "revision": {
-                                "title": "Revision",
-                                "description": "Pin your package to a specific release by specifying a release name",
-                                "type": "string"
-                            },
-                            "subdirectory": {
-                                "title": "Repo subdirectory",
-                                "description": "Subdirectory of the repo where the dbt package is located",
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "git"
-                        ],
-                        "properties": {
-                            "git": {
-                                "title": "Git URL",
-                                "type": "string"
-                            },
-                            "revision": {
-                                "title": "Revision",
-                                "description": "Pin your package to a specific release by specifying a release name",
-                                "type": "string"
-                            },
-                            "subdirectory": {
-                                "title": "Subdirectory",
-                                "description": "Only required if the package is nested in a subdirectory of the git project",
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "required": [
-                            "name",
-                            "tarball"
-                        ],
-                        "properties": {
-                            "name": {
-                                "description": "dbt will create a subdirectory in your `packages-install-path` with this name, and the tarball's source code will be installed here.",
-                                "type": "string"
-                            },
-                            "tarball": {
-                                "title": "Internally-hosted tarball URL",
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false
-                    },
-                    {
-                        "type": "object",
-                        "properties": {
-                            "local": {
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false
-                    }
-                ]
-            },
-            "minItems": 1
-        }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DbtPackages",
+  "type": "object",
+  "properties": {
+    "packages": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/DbtPackageEntry"
+      }
     },
-    "additionalProperties": false
+    "projects": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/UpstreamProject"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "DbtPackageEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/HubPackage"
+        },
+        {
+          "$ref": "#/definitions/GitPackage"
+        },
+        {
+          "$ref": "#/definitions/LocalPackage"
+        },
+        {
+          "$ref": "#/definitions/PrivatePackage"
+        },
+        {
+          "$ref": "#/definitions/TarballPackage"
+        }
+      ]
+    },
+    "GitPackage": {
+      "type": "object",
+      "required": [
+        "git"
+      ],
+      "properties": {
+        "git": {
+          "description": "Git clone URL of the package repository (e.g. `https://github.com/dbt-labs/dbt_utils.git`).",
+          "type": "string"
+        },
+        "revision": {
+          "description": "Revision to check out: a tag, branch, or commit SHA.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "subdirectory": {
+          "description": "Subdirectory of the repo where the dbt package is located.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "warn-unpinned": {
+          "description": "Suppress the warning emitted when `revision` is unpinned (i.e. a branch name like `main`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "HubPackage": {
+      "type": "object",
+      "required": [
+        "package"
+      ],
+      "properties": {
+        "install-prerelease": {
+          "description": "Allow installation of pre-release versions when resolving `version`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "package": {
+          "description": "Package identifier on the dbt package hub, in `org/name` form (e.g. `dbt-labs/dbt_utils`).",
+          "type": "string"
+        },
+        "version": {
+          "description": "Version pin. Accepts a single version string, a list of constraints (e.g. `[\">=1.0.0\", \"<2.0.0\"]`), or a number.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PackageVersion"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "LocalPackage": {
+      "type": "object",
+      "required": [
+        "local"
+      ],
+      "properties": {
+        "local": {
+          "description": "Filesystem path to the local dbt package, relative to the project root.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PackageVersion": {
+      "anyOf": [
+        {
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "PrivatePackage": {
+      "type": "object",
+      "required": [
+        "private"
+      ],
+      "properties": {
+        "private": {
+          "description": "Private package identifier. Two-segment `org/repo` for GitHub or 2-part Azure DevOps (`azure_active_directory`); three-or-more-segment `org/group/repo` for GitLab subgroups or Azure DevOps `org/project/repo` (`ado` / `azure_devops`).",
+          "type": "string",
+          "pattern": "^[\\w\\-\\.]+(/[\\w\\-\\.]+){1,}$"
+        },
+        "provider": {
+          "description": "Git provider. One of `github` (default), `gitlab`, `ado`, `azure_devops`, or `azure_active_directory`. `ado` / `azure_devops` require an `org/project/repo` path; `azure_active_directory` is hosted-only and uses `org/repo`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "revision": {
+          "description": "Revision to check out: a tag, branch, or commit SHA.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "subdirectory": {
+          "description": "Subdirectory of the repo where the dbt package is located.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "warn-unpinned": {
+          "description": "Suppress the warning emitted when `revision` is unpinned (i.e. a branch name like `main`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TarballPackage": {
+      "type": "object",
+      "required": [
+        "tarball"
+      ],
+      "properties": {
+        "tarball": {
+          "description": "HTTPS URL of a `.tar.gz` archive containing the dbt package.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "UpstreamProject": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/schemas/latest_fusion/profiles-latest-fusion.json
+++ b/schemas/latest_fusion/profiles-latest-fusion.json
@@ -1,0 +1,1771 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DbtProfiles",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "AnyValue": true,
+    "DbConfig": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "autocommit": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "autocreate": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "cluster_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "connect_timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "datasharing": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "db_groups": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "host": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "iam_profile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "idc_client_display_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "idc_region": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "idp_listen_port": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "idp_response_timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "issuer_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "method": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "password": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "port": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "ra3_node": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "region": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "retries": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "role": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sslmode": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "threads": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "token_endpoint": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/AnyValue"
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "redshift"
+              ]
+            },
+            "user": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "account": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "auth_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "authenticator": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_session_keep_alive": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "connect_retries": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "connect_timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "execution_timezone": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "host": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "method": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "oauth_client_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "oauth_client_secret": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "password": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "port": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "private_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "private_key_passphrase": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "private_key_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "protocol": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "query_tag": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/QueryTag"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "request_timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "retry_all": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "retry_on_database_errors": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "reuse_connections": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "role": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "s3_stage_vpce_dns_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "threads": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "token": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "snowflake"
+              ]
+            },
+            "user": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "warehouse": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "host": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "keepalives_idle": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "method": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "password": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "port": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "retries": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "role": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "search_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sslcert": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sslkey": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sslmode": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "sslrootcert": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "threads": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "postgres"
+              ]
+            },
+            "user": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "api_endpoint": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_secret": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "compute_region": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "dataproc_batch": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AnyValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "dataproc_cluster_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "dataproc_region": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "execution_project": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "gcs_bucket": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "impersonate_service_account": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "job_creation_timeout_seconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "job_execution_timeout_seconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "job_retries": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "job_retry_deadline_seconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "keyfile": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "keyfile_json": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrMap"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "location": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "maximum_bytes_billed": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "method": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "priority": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "profile_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "quota_project": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "refresh_token": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "retries": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "scopes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "submission_method": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "target_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "threads": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "timeout_seconds": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "token": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "token_uri": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "bigquery"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "host": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "password": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "port": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "role": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "threads": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "trino"
+              ]
+            },
+            "user": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "datafusion"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "auth": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SparkAuth"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "host": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kerberos_service_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "method": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SparkMethod"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "password": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "platform_hint": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "port": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint16",
+              "minimum": 0.0
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "server_side_parameters": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/AnyValue"
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "spark"
+              ]
+            },
+            "use_ssl": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "user": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "auth_type": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_secret": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "compute": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/AnyValue"
+              }
+            },
+            "connect_max_idle": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "connect_retries": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "connect_timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32"
+            },
+            "connection_parameters": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/AnyValue"
+              }
+            },
+            "database": {
+              "default": "hive_metastore",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "host": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "http_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "oauth_redirect_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "oauth_scopes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "retry_all": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "session_properties": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/AnyValue"
+              }
+            },
+            "threads": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "token": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "databricks"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "client_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "data_transform_run_timeout": {
+              "default": 180000,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "database": {
+              "default": "default",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "login_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "method": {
+              "description": "The method to use to authenticate with Salesforce. `jwt_bearer`, `username_password`",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "private_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "private_key_path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "salesforce"
+              ]
+            },
+            "username": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "DuckDB adapter configuration",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "attach": {
+              "description": "External databases to attach.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/DuckDbAttachment"
+              }
+            },
+            "database": {
+              "description": "Database name (defaults to \"main\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "extensions": {
+              "description": "Extensions to load (e.g., [\"httpfs\", \"parquet\"] or [{name: \"duckpgq\", repo: \"community\"}])",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/DuckDbExtension"
+              }
+            },
+            "external_root": {
+              "description": "Root path for external materializations (defaults to \".\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_ducklake": {
+              "description": "Whether the primary database is a DuckLake database. Set to true to enable DuckLake-specific query generation (e.g., DROP without CASCADE). Not needed when the path uses the `ducklake:` scheme, but required for MotherDuck managed DuckLake where the path uses `md:` instead.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "path": {
+              "description": "Path to the DuckDB database file. Defaults to in-memory (:memory:)",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "schema": {
+              "description": "Schema name (defaults to \"main\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "secrets": {
+              "description": "Secrets to register with DuckDB's Secrets Manager.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/DuckDbSecret"
+              }
+            },
+            "settings": {
+              "description": "DuckDB configuration settings (e.g., {\"memory_limit\": \"4GB\"})",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/AnyValue"
+              }
+            },
+            "threads": {
+              "description": "Number of threads",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "duckdb"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "certificate_fingerprint": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "certificate_validation": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "connection_timeout": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "encryption": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "host": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "password": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "port": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "threads": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "exasol"
+              ]
+            },
+            "user": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "PWD": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "UID": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "access_token": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "access_token_expires_on": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "api_url": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "authentication": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_secret": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "driver": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "encrypt": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "host": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "login_timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "query_timeout": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "retries": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "schema_authorization": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "snapshot_timestamp": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "tenant_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "trace_flag": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "trust_cert": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "fabric"
+              ]
+            },
+            "warehouse_snapshot_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "warehouse_snapshot_name": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "windows_login": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "host": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "password": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "port": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "secure": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "threads": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "clickhouse"
+              ]
+            },
+            "user": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "DuckDbAttachment": {
+      "description": "A DuckDB database attachment. Corresponds to upstream dbt-duckdb `Attachment` dataclass. Generates an `ATTACH IF NOT EXISTS` statement.",
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "alias": {
+          "description": "Alias name for the attached database.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "is_ducklake": {
+          "description": "Whether this attachment is a DuckLake database. Set to true to enable DuckLake-specific query generation (e.g., DROP without CASCADE). Not needed when the path uses the `ducklake:` scheme, but required for MotherDuck managed DuckLake where the path uses `md:` instead.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "path": {
+          "description": "Path to the database file or connection string.",
+          "type": "string"
+        },
+        "read_only": {
+          "description": "Whether to attach read-only.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "type": {
+          "description": "Database type (e.g., \"duckdb\", \"sqlite\", \"postgres\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DuckDbExtension": {
+      "description": "DuckDB extension definition — can be a simple string (name) or an object with name and optional repo",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/DuckDbExtensionObject"
+        }
+      ]
+    },
+    "DuckDbExtensionObject": {
+      "description": "DuckDB extension object with name and optional repo metadata",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "repo": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "DuckDbSecret": {
+      "description": "A DuckDB secret for the Secrets Manager. Corresponds to upstream dbt-duckdb `Secret` dataclass. Generates a `CREATE OR REPLACE SECRET` statement.",
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "description": "Optional name. Auto-generated as `__dbt_secret_{index}` if omitted.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "persistent": {
+          "description": "Whether this is a persistent secret (survives restarts).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "provider": {
+          "description": "Optional provider (e.g., \"credential_chain\" for AWS default creds).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scope": {
+          "description": "Optional scope restriction (e.g., \"s3://my-bucket\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "description": "Secret type: s3, azure, gcs, r2, huggingface, etc.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "QueryTag": {
+      "description": "A wrapper type for the `query_tag` config field that handles flexible deserialization.\n\nAccepts strings, dictionaries, or sequences for query_tag. Maps and sequences are JSON-serialized to strings.\n\n# Example\n\n```ignore // Input: \"my-tag\" // Stores as: \"my-tag\"\n\n// Input: {\"project\": \"foo\", \"env\": \"prod\"} // Stores as: \"{\\\"project\\\":\\\"foo\\\",\\\"env\\\":\\\"prod\\\"}\" ```",
+      "type": "string"
+    },
+    "SparkAuth": {
+      "type": "string",
+      "enum": [
+        "NOSASL",
+        "CUSTOM",
+        "KERBEROS",
+        "LDAP",
+        "NONE",
+        "PLAIN",
+        "BASIC",
+        "TOKEN",
+        "AWS_SIGV4"
+      ]
+    },
+    "SparkMethod": {
+      "type": "string",
+      "enum": [
+        "thrift",
+        "http",
+        "livy",
+        "spark-connect"
+      ]
+    },
+    "StringOrInteger": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer",
+          "format": "int64"
+        }
+      ]
+    },
+    "StringOrMap": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/latest_fusion/selectors-latest-fusion.json
+++ b/schemas/latest_fusion/selectors-latest-fusion.json
@@ -1,157 +1,284 @@
 {
-  "title": "selectors",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SelectorFile",
   "type": "object",
   "required": [
     "selectors"
   ],
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "properties": {
     "selectors": {
+      "description": "List of named selectors that may later be referenced with `dbt run --selector <name>`.",
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "default": {
-            "oneOf": [
-              {
-                "type": "string",
-                "pattern": "\\{\\{.*\\}\\}"
-              },
-              {
-                "type": "boolean"
-              }
-            ],
-            "additionalProperties": false
-          },
-          "definition": {
-            "oneOf": [
-              {
-                "$ref": "#/$defs/definition_block"
-              },
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/$defs/union_block"
-              }
-            ]
-          }
+        "$ref": "#/definitions/SelectorDefinition"
+      }
+    },
+    "version": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/FloatOrString"
         },
-        "additionalProperties": false
-      },
-      "minItems": 1
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "additionalProperties": false,
-  "$defs": {
-    "boolean_or_jinja_string": {
-      "oneOf": [
+  "definitions": {
+    "AtomExpr": {
+      "description": "The true leaves: either a method, a shorthand, or an exclude",
+      "anyOf": [
         {
-          "$ref": "#/$defs/jinja_string"
+          "$ref": "#/definitions/MethodAtomExpr"
         },
         {
-          "type": "boolean"
+          "$ref": "#/definitions/ExcludeAtomExpr"
+        },
+        {
+          "description": "Direct method name as key with value",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectorValue"
+          }
         }
+      ]
+    },
+    "CompositeExpr": {
+      "description": "A boolean composition of other selectors",
+      "type": "object",
+      "required": [
+        "kind"
       ],
+      "properties": {
+        "kind": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/CompositeKind"
+          }
+        }
+      },
       "additionalProperties": false
     },
-    "definition_block": {
+    "CompositeKind": {
+      "description": "Is this an `OR` or an `AND`?",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "union"
+          ],
+          "properties": {
+            "union": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SelectorDefinitionValue"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "intersection"
+          ],
+          "properties": {
+            "intersection": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SelectorDefinitionValue"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ExcludeAtomExpr": {
       "type": "object",
+      "required": [
+        "exclude"
+      ],
+      "properties": {
+        "exclude": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SelectorDefinitionValue"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "FloatOrString": {
+      "anyOf": [
+        {
+          "type": "number",
+          "format": "float"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "IndirectSelection": {
+      "type": "string",
+      "enum": [
+        "eager",
+        "buildable",
+        "cautious",
+        "empty"
+      ]
+    },
+    "MethodAtomExpr": {
+      "type": "object",
+      "required": [
+        "method",
+        "value"
+      ],
       "properties": {
         "children": {
-          "$ref": "#/$defs/boolean_or_jinja_string"
+          "default": false,
+          "type": "boolean"
         },
         "children_depth": {
-          "type": "number"
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
         },
         "childrens_parents": {
-          "$ref": "#/$defs/boolean_or_jinja_string"
+          "default": false,
+          "type": "boolean"
+        },
+        "exclude": {
+          "default": null,
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SelectorDefinitionValue"
+          }
         },
         "indirect_selection": {
-          "type": "string",
-          "enum": [
-            "buildable",
-            "cautious",
-            "eager"
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/IndirectSelection"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "method": {
-          "type": "string",
-          "enum": [
-            "config",
-            "exposure",
-            "file",
-            "fqn",
-            "group",
-            "metric",
-            "package",
-            "path",
-            "result",
-            "source",
-            "source_status",
-            "state",
-            "tag",
-            "test_name",
-            "test_type",
-            "wildcard"
-          ]
+          "type": "string"
         },
         "parents": {
-          "$ref": "#/$defs/boolean_or_jinja_string"
+          "default": false,
+          "type": "boolean"
         },
         "parents_depth": {
-          "type": "number"
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
         },
         "value": {
+          "$ref": "#/definitions/SelectorValue"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SelectorDefaultSpec": {
+      "description": "Parsed form of the selector `default:` field: either a literal bool or a still-unrendered Jinja template string.",
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "SelectorDefinition": {
+      "type": "object",
+      "required": [
+        "definition",
+        "name"
+      ],
+      "properties": {
+        "default": {
+          "description": "Whether this selector should be used when the user does *not* pass `--select` / `--selector`.\n\nWrapped in [`Verbatim`] so the Jinja string form is captured unrendered at parse time; rendering happens lazily in `resolve_selectors_from_yaml`, and only when the default is actually needed (no CLI selection was provided). This matches dbt-core behavior: a buggy Jinja expression in a selector the user didn't ask to use must not fail the run.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SelectorDefaultSpec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "definition": {
+          "description": "Either a bare CLI string or a full YAML expression tree.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SelectorDefinitionValue"
+            }
+          ]
+        },
+        "description": {
+          "description": "Human-readable description (optional).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "The key used in `--selector <name>`.",
           "type": "string"
         }
       },
-      "additionalProperties": true
+      "additionalProperties": false
     },
-    "exclude_block": {
-      "type": "array",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "#/$defs/intersection_block"
-          },
-          {
-            "$ref": "#/$defs/definition_block"
-          }
-        ]
-      }
+    "SelectorDefinitionValue": {
+      "anyOf": [
+        {
+          "description": "CLI-style selector string (e.g. `\"snowplow tag:nightly\"`).",
+          "type": "string"
+        },
+        {
+          "description": "Full YAML tree (see `SelectorExpr` below).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/SelectorExpr"
+            }
+          ]
+        }
+      ]
     },
-    "intersection_block": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/definition_block"
-      }
+    "SelectorExpr": {
+      "description": "Top‐level expression: either a boolean node or a single atom",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CompositeExpr"
+        },
+        {
+          "$ref": "#/definitions/AtomExpr"
+        }
+      ]
     },
-    "jinja_string": {
-      "type": "string",
-      "pattern": "\\{\\{.*\\}\\}"
-    },
-    "union_block": {
-      "type": "array",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "#/$defs/intersection_block"
-          },
-          {
-            "$ref": "#/$defs/definition_block"
-          },
-          {
-            "$ref": "#/$defs/exclude_block"
-          }
-        ]
-      }
+    "SelectorValue": {
+      "description": "A selector value that accepts any YAML scalar (string, boolean, number) and normalizes it to a string representation for downstream matching.",
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR syncs the latest fusion JSON schemas from the dbt-fusion repository.

### Files Updated
- `schemas/latest_fusion/dbt_project-latest-fusion.json`
- `schemas/latest_fusion/dbt_yml_files-latest-fusion.json`
- `schemas/latest_fusion/selectors-latest-fusion.json`
- `schemas/latest_fusion/profiles-latest-fusion.json`
- `schemas/latest_fusion/dbt_cloud-latest-fusion.json`
- `schemas/latest_fusion/packages-latest-fusion.json`
- `schemas/latest_fusion/dependencies-latest-fusion.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Ref**: main
- **Commit**: [`23aca00aa3625f48cdac04830ef879af9edece2b`](https://github.com/dbt-labs/fs/commit/23aca00aa3625f48cdac04830ef879af9edece2b)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25504802598)