### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/schemas/latest_fusion/dbt_project-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_project-latest-fusion.json
@@ -438,6 +438,38 @@
         }
       ]
     },
+    "ComputeArg": {
+      "oneOf": [
+        {
+          "description": "Execute on the remote warehouse (Snowflake, BigQuery, etc.)",
+          "type": "string",
+          "enum": [
+            "remote"
+          ]
+        },
+        {
+          "description": "Run computations in-process",
+          "type": "string",
+          "enum": [
+            "inline"
+          ]
+        },
+        {
+          "description": "Run computations in a separate, ephemeral worker process",
+          "type": "string",
+          "enum": [
+            "sidecar"
+          ]
+        },
+        {
+          "description": "Run via the remote compute service (persistent workers/cluster).",
+          "type": "string",
+          "enum": [
+            "service"
+          ]
+        }
+      ]
+    },
     "DataLakeObjectCategory": {
       "description": "See `category` from https://developer.salesforce.com/docs/data/connectapi/references/spec?meta=postDataLakeObject",
       "type": "string",
@@ -1150,6 +1182,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "+compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "+copy_grants": {
@@ -2164,6 +2206,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "+compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "+concurrent_batches": {
@@ -3857,6 +3909,16 @@
             "null"
           ]
         },
+        "+compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "+copy_grants": {
           "default": null,
           "type": [
@@ -4567,6 +4629,7 @@
           ]
         },
         "+freshness": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessDefinition"
@@ -4991,6 +5054,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "+compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "+copy_grants": {

--- a/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
@@ -358,6 +358,15 @@
             "$ref": "#/definitions/AnyValue"
           }
         },
+        "policy_tags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "tags": {
           "anyOf": [
             {
@@ -594,6 +603,38 @@
         "natural",
         "primary",
         "unique"
+      ]
+    },
+    "ComputeArg": {
+      "oneOf": [
+        {
+          "description": "Execute on the remote warehouse (Snowflake, BigQuery, etc.)",
+          "type": "string",
+          "enum": [
+            "remote"
+          ]
+        },
+        {
+          "description": "Run computations in-process",
+          "type": "string",
+          "enum": [
+            "inline"
+          ]
+        },
+        {
+          "description": "Run computations in a separate, ephemeral worker process",
+          "type": "string",
+          "enum": [
+            "sidecar"
+          ]
+        },
+        {
+          "description": "Run via the remote compute service (persistent workers/cluster).",
+          "type": "string",
+          "enum": [
+            "service"
+          ]
+        }
       ]
     },
     "ConstantProperty": {
@@ -933,6 +974,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "copy_grants": {
@@ -4037,6 +4088,16 @@
             "null"
           ]
         },
+        "compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "concurrent_batches": {
           "default": null,
           "type": [
@@ -6562,6 +6623,16 @@
             "null"
           ]
         },
+        "compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "copy_grants": {
           "type": [
             "boolean",
@@ -7562,6 +7633,7 @@
           ]
         },
         "freshness": {
+          "default": null,
           "anyOf": [
             {
               "$ref": "#/definitions/FreshnessDefinition"
@@ -8497,6 +8569,16 @@
             "null"
           ]
         },
+        "compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputeArg"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "copy_grants": {
           "type": [
             "boolean",
@@ -9106,6 +9188,151 @@
         "all"
       ]
     },
+    "VersionColumnProperties": {
+      "description": "Column entry inside a model version block.\n\nUnlike `ColumnProperties`, `name` is optional here because version column lists can contain include/exclude directives (e.g. `include: all, exclude: [col]`) that have no name.",
+      "type": "object",
+      "properties": {
+        "column_mask": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ColumnMask"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "config": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ColumnConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "constraints": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
+        },
+        "data_tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        },
+        "data_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "databricks_tags": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dimension": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ColumnPropertiesDimension"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "entity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Entity"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "exclude": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "granularity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Granularity"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "policy_tags": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "quote": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "tests": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/DataTests"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "Versions": {
       "type": "object",
       "required": [
@@ -9117,6 +9344,16 @@
             "string",
             "null"
           ]
+        },
+        "columns": {
+          "readOnly": true,
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/VersionColumnProperties"
+          }
         },
         "config": {
           "anyOf": [

--- a/schemas/latest_fusion/profiles-latest-fusion.json
+++ b/schemas/latest_fusion/profiles-latest-fusion.json
@@ -1535,25 +1535,123 @@
             "type"
           ],
           "properties": {
-            "database": {
+            "allow_automatic_deduplication": {
+              "default": false,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "check_exchange": {
+              "default": true,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "client_cert": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "client_cert_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cluster": {
+              "default": "",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "cluster_mode": {
+              "default": false,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "compress_block_size": {
+              "default": 1048576,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "compression": {
+              "default": "",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "connect_timeout": {
+              "default": 10,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "custom_settings": {
+              "default": {},
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/AnyValue"
+              }
+            },
+            "database_engine": {
+              "default": "",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "driver": {
+              "description": "Auto-detected from `port` and `secure` when not set.",
               "type": [
                 "string",
                 "null"
               ]
             },
             "host": {
+              "default": "localhost",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "local_db_prefix": {
+              "default": "",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "local_suffix": {
+              "default": "_local",
               "type": [
                 "string",
                 "null"
               ]
             },
             "password": {
+              "default": "",
               "type": [
                 "string",
                 "null"
               ]
             },
             "port": {
+              "description": "Auto-detected from `driver` and `secure` when not set.",
               "anyOf": [
                 {
                   "$ref": "#/definitions/StringOrInteger"
@@ -1563,19 +1661,46 @@
                 }
               ]
             },
+            "retries": {
+              "default": 1,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
             "schema": {
+              "default": "default",
               "type": [
                 "string",
                 "null"
               ]
             },
             "secure": {
+              "default": false,
               "type": [
                 "boolean",
                 "null"
               ]
             },
+            "send_receive_timeout": {
+              "default": 300,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
+            "sync_request_timeout": {
+              "default": 5,
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64"
+            },
             "threads": {
+              "default": 1,
               "anyOf": [
                 {
                   "$ref": "#/definitions/StringOrInteger"
@@ -1591,9 +1716,24 @@
                 "clickhouse"
               ]
             },
+            "use_lw_deletes": {
+              "default": false,
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "user": {
+              "default": "default",
               "type": [
                 "string",
+                "null"
+              ]
+            },
+            "verify": {
+              "default": true,
+              "type": [
+                "boolean",
                 "null"
               ]
             }


### PR DESCRIPTION
## Summary

This PR syncs the latest fusion JSON schemas from the dbt-fusion repository.

### Files Updated
- `schemas/latest_fusion/dbt_project-latest-fusion.json`
- `schemas/latest_fusion/dbt_yml_files-latest-fusion.json`
- `schemas/latest_fusion/selectors-latest-fusion.json`
- `schemas/latest_fusion/profiles-latest-fusion.json`
- `schemas/latest_fusion/dbt_cloud-latest-fusion.json`
- `schemas/latest_fusion/packages-latest-fusion.json`
- `schemas/latest_fusion/dependencies-latest-fusion.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Ref**: main
- **Commit**: [`b07855def3675977866cbc0b0c0b00409ca7c13e`](https://github.com/dbt-labs/fs/commit/b07855def3675977866cbc0b0c0b00409ca7c13e)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25726751331)