### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/schemas/latest_fusion/selectors-latest-fusion.json
+++ b/schemas/latest_fusion/selectors-latest-fusion.json
@@ -139,7 +139,11 @@
       "properties": {
         "children": {
           "default": false,
-          "type": "boolean"
+          "allOf": [
+            {
+              "$ref": "#/definitions/SelectorDefaultSpec"
+            }
+          ]
         },
         "children_depth": {
           "default": null,
@@ -152,7 +156,11 @@
         },
         "childrens_parents": {
           "default": false,
-          "type": "boolean"
+          "allOf": [
+            {
+              "$ref": "#/definitions/SelectorDefaultSpec"
+            }
+          ]
         },
         "exclude": {
           "default": null,
@@ -180,7 +188,11 @@
         },
         "parents": {
           "default": false,
-          "type": "boolean"
+          "allOf": [
+            {
+              "$ref": "#/definitions/SelectorDefaultSpec"
+            }
+          ]
         },
         "parents_depth": {
           "default": null,
@@ -198,7 +210,7 @@
       "additionalProperties": false
     },
     "SelectorDefaultSpec": {
-      "description": "Parsed form of the selector `default:` field: either a literal bool or a still-unrendered Jinja template string.",
+      "description": "Parsed form of the selector `default:` field: either a literal bool or a still-unrendered Jinja template string.\n\nAlso reused for graph-walk flag fields (`children`, `parents`, `childrens_parents`) so the JSON schema correctly shows that those fields accept Jinja expressions.  At runtime those fields are always rendered before deserialization (`into_typed_with_jinja`), so `Template` is only ever populated for `default`.",
       "anyOf": [
         {
           "type": "boolean"
@@ -262,6 +274,13 @@
               "$ref": "#/definitions/SelectorExpr"
             }
           ]
+        },
+        {
+          "description": "Bare YAML sequence — treated as an implicit union of the listed items.\n\ndbt-core allows writing: ```yaml definition: - method: tag value: nightly - method: config value: \"materialized:table\" ``` which is semantically equivalent to `union: [...]`.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SelectorDefinitionValue"
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary

This PR syncs the latest fusion JSON schemas from the dbt-fusion repository.

### Files Updated
- `schemas/latest_fusion/dbt_project-latest-fusion.json`
- `schemas/latest_fusion/dbt_yml_files-latest-fusion.json`
- `schemas/latest_fusion/selectors-latest-fusion.json`
- `schemas/latest_fusion/profiles-latest-fusion.json`
- `schemas/latest_fusion/dbt_cloud-latest-fusion.json`
- `schemas/latest_fusion/packages-latest-fusion.json`
- `schemas/latest_fusion/dependencies-latest-fusion.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Ref**: main
- **Commit**: [`79e8795a50648fdbdc6cefb3cb440648e9d7c640`](https://github.com/dbt-labs/fs/commit/79e8795a50648fdbdc6cefb3cb440648e9d7c640)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25831567943)