### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/schemas/latest_fusion/dbt_project-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_project-latest-fusion.json
@@ -4622,7 +4622,19 @@
             "null"
           ]
         },
+        "+external_location": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+formatter": {
           "type": [
             "string",
             "null"

--- a/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
@@ -7620,6 +7620,12 @@
             "null"
           ]
         },
+        "external_location": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "external_volume": {
           "type": [
             "string",
@@ -7627,6 +7633,12 @@
           ]
         },
         "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "formatter": {
           "type": [
             "string",
             "null"
@@ -8339,6 +8351,18 @@
           ]
         },
         "event_time": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "external_location": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "formatter": {
           "type": [
             "string",
             "null"

--- a/schemas/latest_fusion/selectors-latest-fusion.json
+++ b/schemas/latest_fusion/selectors-latest-fusion.json
@@ -45,55 +45,41 @@
       ]
     },
     "CompositeExpr": {
-      "description": "A boolean composition of other selectors",
+      "description": "A boolean composition of other selectors.\n\nSupports three forms from dbt-core's YAML spec: - `union: [...]` - `intersection: [...]` - `union: [...]\\nexclude: [...]` — top-level exclude applied after the union\n\nExactly one of `union` / `intersection` must be present; `exclude` is always optional. The generated JSON schema allows all three keys (no `oneOf` constraint) to avoid false-positive IDE squiggles on the common `union + exclude` pattern.",
       "type": "object",
-      "required": [
-        "kind"
-      ],
       "properties": {
-        "kind": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/CompositeKind"
+        "exclude": {
+          "description": "Models excluded from the composite result.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SelectorDefinitionValue"
+          }
+        },
+        "intersection": {
+          "description": "AND of all listed selectors.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SelectorDefinitionValue"
+          }
+        },
+        "union": {
+          "description": "OR of all listed selectors.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/SelectorDefinitionValue"
           }
         }
       },
       "additionalProperties": false
-    },
-    "CompositeKind": {
-      "description": "Is this an `OR` or an `AND`?",
-      "oneOf": [
-        {
-          "type": "object",
-          "required": [
-            "union"
-          ],
-          "properties": {
-            "union": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SelectorDefinitionValue"
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "type": "object",
-          "required": [
-            "intersection"
-          ],
-          "properties": {
-            "intersection": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/SelectorDefinitionValue"
-              }
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
     },
     "ExcludeAtomExpr": {
       "type": "object",
@@ -184,6 +170,7 @@
           ]
         },
         "method": {
+          "description": "Selector method name. Standard values: `access`, `config`, `exposure`, `file`, `fqn`, `group`, `metric`, `package`, `path`, `resource_type`, `result`, `saved_query`, `semantic_model`, `source`, `source_status`, `state`, `tag`, `test_name`, `test_type`, `unit_test`, `version`. YAML-only: `selector` (references another named selector). Dot-notation adds a sub-argument: `config.materialized`, `config.schema`, etc.",
           "type": "string"
         },
         "parents": {


### PR DESCRIPTION
## Summary

This PR syncs the latest fusion JSON schemas from the dbt-fusion repository.

### Files Updated
- `schemas/latest_fusion/dbt_project-latest-fusion.json`
- `schemas/latest_fusion/dbt_yml_files-latest-fusion.json`
- `schemas/latest_fusion/selectors-latest-fusion.json`
- `schemas/latest_fusion/profiles-latest-fusion.json`
- `schemas/latest_fusion/dbt_cloud-latest-fusion.json`
- `schemas/latest_fusion/packages-latest-fusion.json`
- `schemas/latest_fusion/dependencies-latest-fusion.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Ref**: main
- **Commit**: [`b489baf8495d33f50111ff95f9ad135a6ff4050f`](https://github.com/dbt-labs/fs/commit/b489baf8495d33f50111ff95f9ad135a6ff4050f)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/25881087408)