### PR TITLE
feat(latest_fusion/packages): typed PrivatePackageProvider enum for provider field

### DIFF
--- a/schemas/latest_fusion/packages-latest-fusion.json
+++ b/schemas/latest_fusion/packages-latest-fusion.json
@@ -141,15 +141,19 @@
       ],
       "properties": {
         "private": {
-          "description": "Private package identifier. Two-segment `org/repo` for GitHub or 2-part Azure DevOps (`azure_active_directory`); three-or-more-segment `org/group/repo` for GitLab subgroups or Azure DevOps `org/project/repo` (`ado` / `azure_devops`).",
+          "description": "Private package identifier. Two-segment `org/repo` for GitHub, GitLab, or Azure DevOps; three-or-more-segment `org/group/repo` for GitLab subgroups or Azure DevOps `org/project/repo` (`ado` / `azure_devops`) when you want to pin the project explicitly.",
           "type": "string",
           "pattern": "^[\\w\\-\\.]+(/[\\w\\-\\.]+){1,}$"
         },
         "provider": {
-          "description": "Git provider. One of `github` (default), `gitlab`, `ado`, `azure_devops`, or `azure_active_directory`. `ado` / `azure_devops` require an `org/project/repo` path; `azure_active_directory` is hosted-only and uses `org/repo`.",
-          "type": [
-            "string",
-            "null"
+          "description": "Git provider. `ado` and `azure_devops` are aliases and accept both `org/repo` (project from URL template) and `org/project/repo` paths. `azure_active_directory` is hosted-only and uses `org/repo`. Defaults to `github` when omitted.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PrivatePackageProvider"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "revision": {
@@ -175,6 +179,17 @@
         }
       },
       "additionalProperties": false
+    },
+    "PrivatePackageProvider": {
+      "description": "Git provider for a private package.\n\n`ado` and `azure_devops` are aliases and behave identically. `azure_active_directory` is a legacy hosted-only provider that uses 2-part `org/repo` paths.",
+      "type": "string",
+      "enum": [
+        "github",
+        "gitlab",
+        "ado",
+        "azure_devops",
+        "azure_active_directory"
+      ]
     },
     "TarballPackage": {
       "type": "object",

--- a/schemas/latest_fusion/packages-latest-fusion.json
+++ b/schemas/latest_fusion/packages-latest-fusion.json
@@ -146,7 +146,7 @@
           "pattern": "^[\\w\\-\\.]+(/[\\w\\-\\.]+){1,}$"
         },
         "provider": {
-          "description": "Git provider. `ado` and `azure_devops` are aliases and accept both `org/repo` (project from URL template) and `org/project/repo` paths. `azure_active_directory` is hosted-only and uses `org/repo`. Defaults to `github` when omitted.",
+          "description": "Git provider. Defaults to `github` when omitted. Use `ado` for Azure DevOps — `azure_devops` and `azure_active_directory` are legacy aliases.",
           "anyOf": [
             {
               "$ref": "#/definitions/PrivatePackageProvider"
@@ -181,7 +181,7 @@
       "additionalProperties": false
     },
     "PrivatePackageProvider": {
-      "description": "Git provider for a private package.\n\n`ado` and `azure_devops` are aliases and behave identically. `azure_active_directory` is a legacy hosted-only provider that uses 2-part `org/repo` paths.",
+      "description": "Git provider for a private package.\n\nUse `ado` (canonical). `azure_devops` and `azure_active_directory` are legacy aliases accepted for backward compatibility — prefer `ado` for new configurations.",
       "type": "string",
       "enum": [
         "github",


### PR DESCRIPTION
## DO NOT MERGE — companion diff for dbt-labs/fs#10278

This PR shows the JSON schema diff that results from [dbt-labs/fs#10278](https://github.com/dbt-labs/fs/pull/10278), which replaces the stringly-typed `provider` field on `PrivatePackage` with a `PrivatePackageProvider` enum.

Schema generated via:
\`\`\`
dbt man --schema packages
\`\`\`
from the `typed-provider-enum` branch of `dbt-labs/fs`.

## What changed

**`PrivatePackage.provider`** — before:
\`\`\`json
"provider": {
  "description": "Git provider. One of ...",
  "type": ["string", "null"]
}
\`\`\`

After:
\`\`\`json
"provider": {
  "description": "Git provider. `ado` and `azure_devops` are aliases...",
  "anyOf": [
    { "$ref": "#/definitions/PrivatePackageProvider" },
    { "type": "null" }
  ]
}
\`\`\`

**New `PrivatePackageProvider` definition:**
\`\`\`json
"PrivatePackageProvider": {
  "description": "Git provider for a private package. ...",
  "type": "string",
  "enum": ["github", "gitlab", "ado", "azure_devops", "azure_active_directory"]
}
\`\`\`

**`PrivatePackage.private`** — description updated to reflect that GitLab and ADO also support 2-part paths.

Merge this after dbt-labs/fs#10278 lands and the schema is regenerated from main.