### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/schemas/latest_fusion/dbt_cloud-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_cloud-latest-fusion.json
@@ -18,6 +18,16 @@
         "$ref": "#/definitions/DbtCloudProject"
       }
     },
+    "state": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DbtCloudState"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "version": {
       "type": "string"
     }
@@ -79,6 +89,23 @@
           "type": "string"
         },
         "token-value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "DbtCloudState": {
+      "description": "Represents the OAuth client credentials for dbt State authentication. Sourced from the optional `state:` section in `~/.dbt/dbt_cloud.yml`.",
+      "type": "object",
+      "required": [
+        "client-id",
+        "client-secret"
+      ],
+      "properties": {
+        "client-id": {
+          "type": "string"
+        },
+        "client-secret": {
           "type": "string"
         }
       },

--- a/schemas/latest_fusion/dbt_project-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_project-latest-fusion.json
@@ -534,6 +534,13 @@
           ]
         },
         {
+          "description": "legacy (ClickHouse only) — intermediate-table + swap approach https://github.com/ClickHouse/dbt-clickhouse/blob/main/dbt/adapters/clickhouse/impl.py",
+          "type": "string",
+          "enum": [
+            "legacy"
+          ]
+        },
+        {
           "type": "object",
           "required": [
             "custom"
@@ -605,21 +612,18 @@
       "type": "object",
       "properties": {
         "database": {
-          "default": null,
           "type": [
             "boolean",
             "null"
           ]
         },
         "identifier": {
-          "default": null,
           "type": [
             "boolean",
             "null"
           ]
         },
         "schema": {
-          "default": null,
           "type": [
             "boolean",
             "null"
@@ -700,6 +704,18 @@
           ]
         },
         "filter": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "loaded_at_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "loaded_at_query": {
           "type": [
             "string",
             "null"
@@ -853,6 +869,25 @@
         "$ref": "#/definitions/PostgresIndex"
       }
     },
+    "LatestVersionPointer": {
+      "description": "Represents the latest version view configuration for versioned models. Supports shorthand (bool) and full form ({enabled: bool, alias: string}).",
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "LogPath": {
       "type": "string",
       "enum": [
@@ -908,6 +943,54 @@
       },
       "additionalProperties": false
     },
+    "ModelState": {
+      "type": "object",
+      "properties": {
+        "evaluate_volatile_sql": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "execute_hooks_on_reuse": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "lag_tolerance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelFreshnessRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pre_clone": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StatePreClone"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "require_fresh_data_from": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UpdatesOn"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "OnConfigurationChange": {
       "type": "string",
       "enum": [
@@ -948,6 +1031,26 @@
         },
         {
           "$ref": "#/definitions/BigqueryPartitionConfig"
+        }
+      ]
+    },
+    "PartitionsConfig": {
+      "description": "External-table style `partitions` config — list-of-strings (e.g. `['ds=2023-01-01']`) or list-of-maps (e.g. `[{name: foo, data_type: varchar}]`, as used by `dbt-external-tables`).",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/AnyValue"
+            }
+          }
         }
       ]
     },
@@ -1201,6 +1304,13 @@
             "null"
           ]
         },
+        "+copy_tags": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "+database": {
           "type": [
             "string",
@@ -1444,13 +1554,14 @@
           "minimum": 0.0
         },
         "+partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+query_tag": {
           "anyOf": [
@@ -1481,6 +1592,12 @@
           "format": "double"
         },
         "+refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -2242,6 +2359,13 @@
             "null"
           ]
         },
+        "+copy_tags": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "+create_notebook": {
           "default": null,
           "type": [
@@ -2530,6 +2654,16 @@
             "null"
           ]
         },
+        "+latest_version_pointer": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LatestVersionPointer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "+liquid_clustered_by": {
           "anyOf": [
             {
@@ -2713,13 +2847,14 @@
           "minimum": 0.0
         },
         "+partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+persist_docs": {
           "anyOf": [
@@ -2812,6 +2947,12 @@
           "format": "double"
         },
         "+refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -2930,6 +3071,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "+state": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelState"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "+static_analysis": {
@@ -3269,6 +3420,12 @@
             "null"
           ]
         },
+        "+copy_tags": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "+database": {
           "type": [
             "string",
@@ -3509,13 +3666,14 @@
           "minimum": 0.0
         },
         "+partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+persist_docs": {
           "anyOf": [
@@ -3581,6 +3739,12 @@
           "format": "double"
         },
         "+refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -3926,6 +4090,13 @@
             "null"
           ]
         },
+        "+copy_tags": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "+database": {
           "type": [
             "string",
@@ -4202,13 +4373,14 @@
           "minimum": 0.0
         },
         "+partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+persist_docs": {
           "anyOf": [
@@ -4276,6 +4448,12 @@
           "format": "double"
         },
         "+refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -4809,13 +4987,14 @@
           "minimum": 0.0
         },
         "+partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+quoting": {
           "anyOf": [
@@ -5085,6 +5264,13 @@
             "null"
           ]
         },
+        "+copy_tags": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "+databricks_compute": {
           "type": [
             "string",
@@ -5290,13 +5476,14 @@
           "minimum": 0.0
         },
         "+partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+query_tag": {
           "anyOf": [
@@ -5317,6 +5504,12 @@
           "format": "double"
         },
         "+refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "+refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -5645,6 +5838,14 @@
             "type": "string"
           }
         }
+      ]
+    },
+    "StatePreClone": {
+      "type": "string",
+      "enum": [
+        "never",
+        "if_missing",
+        "always"
       ]
     },
     "StaticAnalysisKind": {

--- a/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
@@ -680,6 +680,7 @@
         },
         "to_columns": {
           "description": "Only ForeignKey constraints accept: a list columns in that table containing the corresponding primary or unique key.",
+          "default": [],
           "type": [
             "array",
             "null"
@@ -987,6 +988,12 @@
           ]
         },
         "copy_grants": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "copy_tags": {
           "type": [
             "boolean",
             "null"
@@ -1300,13 +1307,14 @@
           "minimum": 0.0
         },
         "partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "primary_key": {
           "default": null,
@@ -1344,6 +1352,12 @@
           "format": "double"
         },
         "refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -1692,6 +1706,13 @@
           ]
         },
         {
+          "description": "legacy (ClickHouse only) — intermediate-table + swap approach https://github.com/ClickHouse/dbt-clickhouse/blob/main/dbt/adapters/clickhouse/impl.py",
+          "type": "string",
+          "enum": [
+            "legacy"
+          ]
+        },
+        {
           "type": "object",
           "required": [
             "custom"
@@ -1785,21 +1806,18 @@
       "type": "object",
       "properties": {
         "database": {
-          "default": null,
           "type": [
             "boolean",
             "null"
           ]
         },
         "identifier": {
-          "default": null,
           "type": [
             "boolean",
             "null"
           ]
         },
         "schema": {
-          "default": null,
           "type": [
             "boolean",
             "null"
@@ -2277,6 +2295,18 @@
             "null"
           ]
         },
+        "loaded_at_field": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "loaded_at_query": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "warn_after": {
           "default": {
             "count": null,
@@ -2502,6 +2532,12 @@
           ]
         },
         "copy_grants": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "copy_tags": {
           "type": [
             "boolean",
             "null"
@@ -2813,13 +2849,14 @@
           "minimum": 0.0
         },
         "partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "primary_key": {
           "default": null,
@@ -2857,6 +2894,12 @@
           "format": "double"
         },
         "refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -3434,6 +3477,25 @@
       "items": {
         "$ref": "#/definitions/PostgresIndex"
       }
+    },
+    "LatestVersionPointer": {
+      "description": "Represents the latest version view configuration for versioned models. Supports shorthand (bool) and full form ({enabled: bool, alias: string}).",
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "MacrosArguments": {
       "type": "object",
@@ -4121,6 +4183,12 @@
             "null"
           ]
         },
+        "copy_tags": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "create_notebook": {
           "type": [
             "boolean",
@@ -4399,6 +4467,16 @@
             "null"
           ]
         },
+        "latest_version_pointer": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LatestVersionPointer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "liquid_clustered_by": {
           "anyOf": [
             {
@@ -4579,13 +4657,14 @@
           "minimum": 0.0
         },
         "partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "persist_docs": {
           "anyOf": [
@@ -4677,6 +4756,12 @@
           "format": "double"
         },
         "refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -4790,6 +4875,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "state": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelState"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "static_analysis": {
@@ -4976,7 +5071,7 @@
         },
         "to_columns": {
           "description": "Only ForeignKey constraints accept: a list columns in that table containing the corresponding primary or unique key.",
-          "default": null,
+          "default": [],
           "type": [
             "array",
             "null"
@@ -5264,6 +5359,54 @@
       },
       "additionalProperties": false
     },
+    "ModelState": {
+      "type": "object",
+      "properties": {
+        "evaluate_volatile_sql": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "execute_hooks_on_reuse": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "lag_tolerance": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ModelFreshnessRules"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pre_clone": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StatePreClone"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "require_fresh_data_from": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/UpdatesOn"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "OnConfigurationChange": {
       "type": "string",
       "enum": [
@@ -5304,6 +5447,26 @@
         },
         {
           "$ref": "#/definitions/BigqueryPartitionConfig"
+        }
+      ]
+    },
+    "PartitionsConfig": {
+      "description": "External-table style `partitions` config — list-of-strings (e.g. `['ds=2023-01-01']`) or list-of-maps (e.g. `[{name: foo, data_type: varchar}]`, as used by `dbt-external-tables`).",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/AnyValue"
+            }
+          }
         }
       ]
     },
@@ -5791,6 +5954,12 @@
             "null"
           ]
         },
+        "copy_tags": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "data_retention_time_in_days": {
           "type": [
             "integer",
@@ -6109,13 +6278,14 @@
           "minimum": 0.0
         },
         "partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "persist_docs": {
           "anyOf": [
@@ -6190,6 +6360,12 @@
           "format": "double"
         },
         "refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -6639,6 +6815,12 @@
             "null"
           ]
         },
+        "copy_tags": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "data_retention_time_in_days": {
           "type": [
             "integer",
@@ -6975,13 +7157,14 @@
           "minimum": 0.0
         },
         "partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "persist_docs": {
           "anyOf": [
@@ -7056,6 +7239,12 @@
           "format": "double"
         },
         "refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -7554,6 +7743,12 @@
             "null"
           ]
         },
+        "copy_tags": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "data_retention_time_in_days": {
           "type": [
             "integer",
@@ -7855,13 +8050,14 @@
           "minimum": 0.0
         },
         "partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "primary_key": {
           "default": null,
@@ -7899,6 +8095,12 @@
           "format": "double"
         },
         "refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_warehouse": {
           "type": [
             "string",
             "null"
@@ -8186,6 +8388,14 @@
         }
       },
       "additionalProperties": false
+    },
+    "StatePreClone": {
+      "type": "string",
+      "enum": [
+        "never",
+        "if_missing",
+        "always"
+      ]
     },
     "StaticAnalysisKind": {
       "type": "string",
@@ -8609,6 +8819,12 @@
             "null"
           ]
         },
+        "copy_tags": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "data_retention_time_in_days": {
           "type": [
             "integer",
@@ -8868,13 +9084,14 @@
           "minimum": 0.0
         },
         "partitions": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PartitionsConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "primary_key": {
           "default": null,
@@ -8902,6 +9119,12 @@
           "format": "double"
         },
         "refresh_mode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "refresh_warehouse": {
           "type": [
             "string",
             "null"

--- a/schemas/latest_fusion/profiles-latest-fusion.json
+++ b/schemas/latest_fusion/profiles-latest-fusion.json
@@ -13,6 +13,12 @@
             "type"
           ],
           "properties": {
+            "access_key_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "autocommit": {
               "type": [
                 "boolean",
@@ -58,6 +64,12 @@
               "items": {
                 "type": "string"
               }
+            },
+            "drop_without_cascade": {
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "host": {
               "type": [
@@ -156,6 +168,12 @@
                 "null"
               ]
             },
+            "secret_access_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "sslmode": {
               "type": [
                 "string",
@@ -246,6 +264,12 @@
                 "null"
               ]
             },
+            "driver_log_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "execution_timezone": {
               "type": [
                 "string",
@@ -253,6 +277,12 @@
               ]
             },
             "host": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "metadata_warehouse": {
               "type": [
                 "string",
                 "null"
@@ -283,9 +313,13 @@
               ]
             },
             "port": {
-              "type": [
-                "string",
-                "null"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
               ]
             },
             "private_key": {
@@ -1607,6 +1641,12 @@
               "additionalProperties": {
                 "$ref": "#/definitions/AnyValue"
               }
+            },
+            "database": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "database_engine": {
               "default": "",


### PR DESCRIPTION
## Summary

This PR syncs the latest fusion JSON schemas from the dbt-fusion repository.

### Files Updated
- `schemas/latest_fusion/dbt_project-latest-fusion.json`
- `schemas/latest_fusion/dbt_yml_files-latest-fusion.json`
- `schemas/latest_fusion/selectors-latest-fusion.json`
- `schemas/latest_fusion/profiles-latest-fusion.json`
- `schemas/latest_fusion/dbt_cloud-latest-fusion.json`
- `schemas/latest_fusion/packages-latest-fusion.json`
- `schemas/latest_fusion/dependencies-latest-fusion.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Ref**: main
- **Commit**: [`44ce39fe5a8e9df2b95333a3f65ccff42581a116`](https://github.com/dbt-labs/fs/commit/44ce39fe5a8e9df2b95333a3f65ccff42581a116)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/26761472732)