### PR TITLE
feat: add delimiter to seed_configs in 1.7 and latest schemas

### DIFF
--- a/schemas/1.7/dbt_project-1.7.json
+++ b/schemas/1.7/dbt_project-1.7.json
@@ -484,6 +484,9 @@
         "+database": {
           "$ref": "#/$defs/database"
         },
+        "+delimiter": {
+          "type": "string"
+        },
         "+enabled": {
           "$ref": "#/$defs/boolean_or_jinja_string"
         },
@@ -552,6 +555,9 @@
         },
         "database": {
           "$ref": "#/$defs/database"
+        },
+        "delimiter": {
+          "type": "string"
         },
         "schema": {
           "$ref": "#/$defs/schema"

--- a/schemas/latest/dbt_project-latest.json
+++ b/schemas/latest/dbt_project-latest.json
@@ -788,6 +788,9 @@
         "+database": {
           "$ref": "#/$defs/database"
         },
+        "+delimiter": {
+          "type": "string"
+        },
         "+docs": {
           "$ref": "#/$defs/docs_config"
         },
@@ -838,6 +841,9 @@
         },
         "database": {
           "$ref": "#/$defs/database"
+        },
+        "delimiter": {
+          "type": "string"
         },
         "docs": {
           "$ref": "#/$defs/docs_config"

--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -643,6 +643,9 @@
               "database": {
                 "type": "string"
               },
+              "delimiter": {
+                "type": "string"
+              },
               "enabled": {
                 "$ref": "#/$defs/boolean_or_jinja_string"
               },

--- a/tests/1.7/valid/dbt_project.yml
+++ b/tests/1.7/valid/dbt_project.yml
@@ -69,6 +69,8 @@ models:
 seeds:
   test:
     +enabled: false
+    +delimiter: ","
+    delimiter: ","
     empty_subdirectory:
 
 tests:

--- a/tests/latest/valid/dbt_project.yml
+++ b/tests/latest/valid/dbt_project.yml
@@ -79,6 +79,8 @@ unit_tests:
 seeds:
   test:
     +enabled: false
+    +delimiter: ","
+    delimiter: ","
     empty_subdirectory:
 
 tests:

--- a/tests/latest/valid/dbt_yml_files.yml
+++ b/tests/latest/valid/dbt_yml_files.yml
@@ -337,6 +337,12 @@ sources:
             data_tests:
               - unique
 
+seeds:
+  - name: my_seed
+    description: "A seed file"
+    config:
+      delimiter: ","
+
 data_tests:
   - name: my_cool_custom_test
     description: "This checks that all numbers are positive, if it fails you should talk to data engineering"


### PR DESCRIPTION
## Summary

- Adds `delimiter` and `+delimiter` properties to `seed_configs` in `schemas/1.7/dbt_project-1.7.json` and `schemas/latest/dbt_project-latest.json`
- Adds `delimiter` to the seeds `config` block in `schemas/latest/dbt_yml_files-latest.json`
- Adds corresponding test cases in `tests/1.7/valid/dbt_project.yml`, `tests/latest/valid/dbt_project.yml`, and `tests/latest/valid/dbt_yml_files.yml`

Closes #171 (originally opened by @judahrand, pending for ~8 months with no activity).

`delimiter` has been supported since dbt v1.7 per the [official docs](https://docs.getdbt.com/reference/resource-configs/delimiter). The fusion schema already includes this property — this PR brings the hand-maintained schemas in line.

## Test plan

- [x] `npx ajv-cli test -s schemas/latest/dbt_project-latest.json -d tests/latest/valid/dbt_project.yml --valid` passes
- [x] `npx ajv-cli test -s schemas/1.7/dbt_project-1.7.json -d tests/1.7/valid/dbt_project.yml --valid` passes
- [x] `npx ajv-cli test -s schemas/latest/dbt_yml_files-latest.json -d tests/latest/valid/dbt_yml_files.yml --valid` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)