### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/schemas/latest_fusion/dbt_project-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_project-latest-fusion.json
@@ -780,6 +780,19 @@
         "table"
       ]
     },
+    "FunctionSnowflakeConfig": {
+      "description": "Snowflake-specific configuration for functions. Nested under the `snowflake` key inside `config:` in schema YAML (or `+snowflake:` under `functions:` in `dbt_project.yml`).",
+      "type": "object",
+      "properties": {
+        "quote_args": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "GrantAccessToTarget": {
       "type": "object",
       "properties": {
@@ -952,7 +965,7 @@
             "null"
           ]
         },
-        "execute_hooks_on_reuse": {
+        "execute_hooks_on_any_reuse": {
           "type": [
             "boolean",
             "null"
@@ -1610,6 +1623,12 @@
             "null"
           ]
         },
+        "+reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+row_access_policy": {
           "type": [
             "string",
@@ -2049,6 +2068,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "+snowflake": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FunctionSnowflakeConfig"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "+static_analysis": {
@@ -2965,6 +2994,12 @@
             "null"
           ]
         },
+        "+reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+resource_tags": {
           "type": [
             "object",
@@ -3756,6 +3791,12 @@
             "null"
           ]
         },
+        "+reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+row_access_policy": {
           "type": [
             "string",
@@ -4466,6 +4507,12 @@
             "null"
           ]
         },
+        "+reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "+row_access_policy": {
           "type": [
             "string",
@@ -4996,16 +5043,6 @@
             }
           ]
         },
-        "+quoting": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DbtQuoting"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "+refresh_interval_minutes": {
           "default": null,
           "type": [
@@ -5018,6 +5055,12 @@
           "default": null,
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "+reservation": {
+          "type": [
+            "string",
             "null"
           ]
         },
@@ -5519,6 +5562,12 @@
           "default": null,
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "+reservation": {
+          "type": [
+            "string",
             "null"
           ]
         },

--- a/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
@@ -1369,6 +1369,12 @@
             "null"
           ]
         },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "resource_tags": {
           "type": [
             "object",
@@ -2253,6 +2259,82 @@
         "application"
       ]
     },
+    "ExternalPartition": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/ExternalPartitionConfig"
+        }
+      ]
+    },
+    "ExternalPartitionConfig": {
+      "description": "Reference: https://github.com/dbt-labs/dbt-mantle/blob/da5abca4f829b167bd1b1d5c6666c12cd8c719c0/core/dbt/artifacts/resources/v1/source_definition.py#L36",
+      "type": "object",
+      "properties": {
+        "data_type": {
+          "default": "",
+          "type": "string"
+        },
+        "description": {
+          "default": "",
+          "type": "string"
+        },
+        "meta": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/AnyValue"
+          }
+        },
+        "name": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExternalTable": {
+      "description": "Reference: https://github.com/dbt-labs/dbt-mantle/blob/da5abca4f829b167bd1b1d5c6666c12cd8c719c0/core/dbt/artifacts/resources/v1/source_definition.py#L48 These always get serialized, even if none.",
+      "type": "object",
+      "properties": {
+        "file_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "location": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "partitions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ExternalPartition"
+          }
+        },
+        "row_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tbl_properties": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "FloatOrString": {
       "anyOf": [
         {
@@ -2911,6 +2993,12 @@
             "null"
           ]
         },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "resource_tags": {
           "type": [
             "object",
@@ -2970,6 +3058,16 @@
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "snowflake": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FunctionSnowflakeConfig"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "snowflake_initialization_warehouse": {
@@ -3284,6 +3382,19 @@
         "description": {
           "type": [
             "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "FunctionSnowflakeConfig": {
+      "description": "Snowflake-specific configuration for functions. Nested under the `snowflake` key inside `config:` in schema YAML (or `+snowflake:` under `functions:` in `dbt_project.yml`).",
+      "type": "object",
+      "properties": {
+        "quote_args": {
+          "type": [
+            "boolean",
             "null"
           ]
         }
@@ -4773,6 +4884,12 @@
             "null"
           ]
         },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "resource_tags": {
           "type": [
             "object",
@@ -5368,7 +5485,7 @@
             "null"
           ]
         },
-        "execute_hooks_on_reuse": {
+        "execute_hooks_on_any_reuse": {
           "type": [
             "boolean",
             "null"
@@ -6377,6 +6494,12 @@
             "null"
           ]
         },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "resource_tags": {
           "type": [
             "object",
@@ -7256,6 +7379,12 @@
             "null"
           ]
         },
+        "reservation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "resource_tags": {
           "type": [
             "object",
@@ -8077,16 +8206,6 @@
             }
           ]
         },
-        "quoting": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/DbtQuoting"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "refresh_interval_minutes": {
           "type": [
             "number",
@@ -8109,6 +8228,12 @@
         "require_partition_filter": {
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "reservation": {
+          "type": [
+            "string",
             "null"
           ]
         },
@@ -8507,7 +8632,7 @@
         "external": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AnyValue"
+              "$ref": "#/definitions/ExternalTable"
             },
             {
               "type": "null"
@@ -9133,6 +9258,12 @@
         "require_partition_filter": {
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "reservation": {
+          "type": [
+            "string",
             "null"
           ]
         },

--- a/schemas/latest_fusion/profiles-latest-fusion.json
+++ b/schemas/latest_fusion/profiles-latest-fusion.json
@@ -726,6 +726,12 @@
                 "null"
               ]
             },
+            "reservation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "retries": {
               "type": [
                 "integer",
@@ -747,6 +753,12 @@
               "items": {
                 "type": "string"
               }
+            },
+            "service_account_impersonation_url": {
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "submission_method": {
               "type": [
@@ -783,6 +795,16 @@
                 "null"
               ]
             },
+            "token_endpoint": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AnyValue"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "token_uri": {
               "type": [
                 "string",
@@ -793,6 +815,12 @@
               "type": "string",
               "enum": [
                 "bigquery"
+              ]
+            },
+            "workload_pool_provider_path": {
+              "type": [
+                "string",
+                "null"
               ]
             }
           },


### PR DESCRIPTION
## Summary

This PR syncs the latest fusion JSON schemas from the dbt-fusion repository.

### Files Updated
- `schemas/latest_fusion/dbt_project-latest-fusion.json`
- `schemas/latest_fusion/dbt_yml_files-latest-fusion.json`
- `schemas/latest_fusion/selectors-latest-fusion.json`
- `schemas/latest_fusion/profiles-latest-fusion.json`
- `schemas/latest_fusion/dbt_cloud-latest-fusion.json`
- `schemas/latest_fusion/packages-latest-fusion.json`
- `schemas/latest_fusion/dependencies-latest-fusion.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Ref**: main
- **Commit**: [`e2bf43c3f53d3686e18d2bbb1a78e2a9f5b2b3f1`](https://github.com/dbt-labs/fs/commit/e2bf43c3f53d3686e18d2bbb1a78e2a9f5b2b3f1)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/27529289237)