### PR TITLE
Add SECURITY.md with vulnerability reporting guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in this project, we encourage you to report it responsibly. **Please do not open a public GitHub issue for security vulnerabilities.**
+
+### Why Security Matters for JSON Schemas
+
+`dbt-jsonschema` defines the JSON schemas that validate dbt project configuration files (`dbt_project.yml`, `packages.yml`, `selectors.yml`, etc.). A malicious or malformed schema could weaken validation across the dbt ecosystem, potentially allowing unsafe configurations to pass undetected.
+
+### How to Report
+
+Use GitHub's built-in private vulnerability reporting to submit your report:
+
+1. Navigate to the **Security** tab of this repository.
+2. Click **"Report a vulnerability"** under **Private vulnerability reporting**.
+3. Fill out the advisory form with as much detail as possible.
+
+Alternatively, you can go directly to:
+
+```
+https://github.com/dbt-labs/dbt-jsonschema/security/advisories/new
+```
+
+### What to Include
+
+To help us understand and resolve the issue quickly, please include:
+
+- A description of the vulnerability and its potential impact.
+- Step-by-step instructions to reproduce the issue.
+- The affected schema file(s) and version(s).
+- Any relevant logs, screenshots, or proof-of-concept code.
+- Your suggested severity (Critical, High, Medium, Low) if you have one.
+
+### What to Expect
+
+- **Acknowledgment:** We will acknowledge receipt of your report within **3 business days**.
+- **Updates:** We will provide status updates as we investigate, typically within **10 business days**.
+- **Resolution:** Once a fix is ready, we will coordinate disclosure with you before making any public announcement.
+
+### Scope
+
+This policy applies to the latest supported release of this project. If you are unsure whether a version is still supported, please include the version details in your report and we will let you know.
+
+### Guidelines
+
+We ask that you:
+
+- Give us a reasonable amount of time to address the issue before making any public disclosure.
+- Make a good-faith effort to avoid disrupting the project, its infrastructure, or its users during your research.
+- Do not access, modify, or delete data that does not belong to you.
+
+## Supported Versions
+
+| Version     | Supported |
+| ----------- | --------- |
+| latest      | Yes       |
+
+For questions about which versions are actively maintained, please refer to the project's release documentation.
+
+## Thank You
+
+We appreciate the security research community's efforts in helping keep dbt Labs and our users safe. Responsible disclosure makes the open-source ecosystem stronger for everyone.
+
+For urgent or critical issues, please reach out to the [dbt Labs Security Team](mailto:security+ghreport@dbtlabs.com).


### PR DESCRIPTION
## Summary

- Adds a `SECURITY.md` file adapted from the dbt-labs org-wide security policy template.
- Includes context specific to dbt-jsonschema's role as the canonical source of JSON schemas that validate dbt project configuration files.
- Directs reporters to GitHub's private vulnerability reporting and the dbt Labs security team.

## Why

This repository currently has no `SECURITY.md`. Since these schemas are consumed across the dbt ecosystem to validate project configurations, having a clear vulnerability reporting process is important.

## Test plan

- [x] Content follows the dbt-labs org-wide security policy structure
- [x] Reporting URLs point to the correct repository
- [x] Contact email matches the org-wide template