### PR TITLE
chore: sync JSON schemas from dbt-fusion

### DIFF
--- a/schemas/latest_fusion/catalogs-latest-fusion.json
+++ b/schemas/latest_fusion/catalogs-latest-fusion.json
@@ -1,0 +1,1388 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "description": "Top-level `catalogs.yml` (v2) schema.",
+  "properties": {
+    "catalogs": {
+      "items": {
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "description": "Snowflake-managed Iceberg catalog (Horizon). Supports snowflake (native), databricks, and/or duckdb (read-only attach) connection blocks.",
+            "properties": {
+              "config": {
+                "additionalProperties": false,
+                "minProperties": 1,
+                "properties": {
+                  "alt": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "access_delegation_mode": {
+                        "enum": [
+                          "VENDED_CREDENTIALS",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "attach_as": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "authorization_type": {
+                        "enum": [
+                          "OAUTH2",
+                          "SIGV4",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "default_region": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "default_schema": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "disable_multi_table_commit": {
+                        "description": "Disable multi-table commits (Unity write-compat default).",
+                        "type": "boolean"
+                      },
+                      "encode_entire_prefix": {
+                        "type": "boolean"
+                      },
+                      "endpoint": {
+                        "description": "Full REST catalog URL. Mutually exclusive with endpoint_type.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "endpoint_type": {
+                        "description": "Managed endpoint type. Mutually exclusive with endpoint.",
+                        "enum": [
+                          "GLUE",
+                          "S3_TABLES"
+                        ],
+                        "type": "string"
+                      },
+                      "max_table_staleness": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "purge_requested": {
+                        "type": "boolean"
+                      },
+                      "read_only": {
+                        "description": "Attach the catalog read-only. Read-write (read_only: false) on Horizon/Unity requires DuckDB 1.5.4 / duckdb-iceberg#1017.",
+                        "type": "boolean"
+                      },
+                      "remove_files_on_delete": {
+                        "description": "Remove underlying data files when a table is dropped (write-compat).",
+                        "type": "boolean"
+                      },
+                      "secret": {
+                        "description": "Name of a DuckDB secret from profiles.yml to use for authentication.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "skip_create_table_metadata_updates": {
+                        "description": "Skip metadata updates on CREATE TABLE (write-compat).",
+                        "type": "boolean"
+                      },
+                      "stage_create_tables": {
+                        "description": "Opt into staged CREATE TABLE AS SELECT writes (direct CTAS into the target catalog).",
+                        "type": "boolean"
+                      },
+                      "support_nested_namespaces": {
+                        "type": "boolean"
+                      },
+                      "support_stage_create": {
+                        "type": "boolean"
+                      },
+                      "warehouse": {
+                        "description": "S3 warehouse URI. Required when endpoint_type is S3_TABLES.",
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "databricks": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "catalog_database": {
+                        "description": "Name of the Databricks database linked to the external Horizon catalog.",
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "catalog_database"
+                    ],
+                    "type": "object"
+                  },
+                  "duckdb": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "access_delegation_mode": {
+                        "enum": [
+                          "VENDED_CREDENTIALS",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "attach_as": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "authorization_type": {
+                        "enum": [
+                          "OAUTH2",
+                          "SIGV4",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "default_region": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "default_schema": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "disable_multi_table_commit": {
+                        "description": "Disable multi-table commits (Unity write-compat default).",
+                        "type": "boolean"
+                      },
+                      "encode_entire_prefix": {
+                        "type": "boolean"
+                      },
+                      "endpoint": {
+                        "description": "Full REST catalog URL. Mutually exclusive with endpoint_type.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "endpoint_type": {
+                        "description": "Managed endpoint type. Mutually exclusive with endpoint.",
+                        "enum": [
+                          "GLUE",
+                          "S3_TABLES"
+                        ],
+                        "type": "string"
+                      },
+                      "max_table_staleness": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "purge_requested": {
+                        "type": "boolean"
+                      },
+                      "read_only": {
+                        "description": "Attach the catalog read-only. Read-write (read_only: false) on Horizon/Unity requires DuckDB 1.5.4 / duckdb-iceberg#1017.",
+                        "type": "boolean"
+                      },
+                      "remove_files_on_delete": {
+                        "description": "Remove underlying data files when a table is dropped (write-compat).",
+                        "type": "boolean"
+                      },
+                      "secret": {
+                        "description": "Name of a DuckDB secret from profiles.yml to use for authentication.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "skip_create_table_metadata_updates": {
+                        "description": "Skip metadata updates on CREATE TABLE (write-compat).",
+                        "type": "boolean"
+                      },
+                      "stage_create_tables": {
+                        "description": "Opt into staged CREATE TABLE AS SELECT writes (direct CTAS into the target catalog).",
+                        "type": "boolean"
+                      },
+                      "support_nested_namespaces": {
+                        "type": "boolean"
+                      },
+                      "support_stage_create": {
+                        "type": "boolean"
+                      },
+                      "warehouse": {
+                        "description": "S3 warehouse URI. Required when endpoint_type is S3_TABLES.",
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "snowflake": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "base_location_root": {
+                        "description": "Catalog-wide storage path prefix for all Iceberg tables.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "catalog_database": {
+                        "description": "Snowflake database where models using this catalog should land. When set, takes precedence over model database config and target.database.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "change_tracking": {
+                        "type": "boolean"
+                      },
+                      "data_retention_time_in_days": {
+                        "description": "Days to retain table data after deletion. Range 0–90.",
+                        "maximum": 90,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "external_volume": {
+                        "description": "Non-empty external volume name registered in Snowflake.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "iceberg_version": {
+                        "description": "Iceberg spec version, e.g. 3 for Iceberg V3.",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "max_data_extension_time_in_days": {
+                        "description": "Days beyond the retention period to extend data availability. Range 0–90.",
+                        "maximum": 90,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "storage_serialization_policy": {
+                        "enum": [
+                          "COMPATIBLE",
+                          "OPTIMIZED"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "external_volume"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Unique catalog name within this project.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "table_format": {
+                "const": "iceberg"
+              },
+              "type": {
+                "const": "horizon"
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "table_format",
+              "config"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "description": "AWS Glue catalog. Supports snowflake and/or duckdb connection blocks.",
+            "properties": {
+              "config": {
+                "additionalProperties": false,
+                "minProperties": 1,
+                "properties": {
+                  "alt": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "access_delegation_mode": {
+                        "enum": [
+                          "VENDED_CREDENTIALS",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "attach_as": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "authorization_type": {
+                        "enum": [
+                          "OAUTH2",
+                          "SIGV4",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "default_region": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "default_schema": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "disable_multi_table_commit": {
+                        "description": "Disable multi-table commits (Unity write-compat default).",
+                        "type": "boolean"
+                      },
+                      "encode_entire_prefix": {
+                        "type": "boolean"
+                      },
+                      "endpoint": {
+                        "description": "Full REST catalog URL. Mutually exclusive with endpoint_type.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "endpoint_type": {
+                        "description": "Managed endpoint type. Mutually exclusive with endpoint.",
+                        "enum": [
+                          "GLUE",
+                          "S3_TABLES"
+                        ],
+                        "type": "string"
+                      },
+                      "max_table_staleness": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "purge_requested": {
+                        "type": "boolean"
+                      },
+                      "read_only": {
+                        "description": "Attach the catalog read-only. Read-write (read_only: false) on Horizon/Unity requires DuckDB 1.5.4 / duckdb-iceberg#1017.",
+                        "type": "boolean"
+                      },
+                      "remove_files_on_delete": {
+                        "description": "Remove underlying data files when a table is dropped (write-compat).",
+                        "type": "boolean"
+                      },
+                      "secret": {
+                        "description": "Name of a DuckDB secret from profiles.yml to use for authentication.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "skip_create_table_metadata_updates": {
+                        "description": "Skip metadata updates on CREATE TABLE (write-compat).",
+                        "type": "boolean"
+                      },
+                      "stage_create_tables": {
+                        "description": "Opt into staged CREATE TABLE AS SELECT writes (direct CTAS into the target catalog).",
+                        "type": "boolean"
+                      },
+                      "support_nested_namespaces": {
+                        "type": "boolean"
+                      },
+                      "support_stage_create": {
+                        "type": "boolean"
+                      },
+                      "warehouse": {
+                        "description": "S3 warehouse URI. Required when endpoint_type is S3_TABLES.",
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "duckdb": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "access_delegation_mode": {
+                        "enum": [
+                          "VENDED_CREDENTIALS",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "attach_as": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "authorization_type": {
+                        "enum": [
+                          "OAUTH2",
+                          "SIGV4",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "default_region": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "default_schema": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "disable_multi_table_commit": {
+                        "description": "Disable multi-table commits (Unity write-compat default).",
+                        "type": "boolean"
+                      },
+                      "encode_entire_prefix": {
+                        "type": "boolean"
+                      },
+                      "endpoint": {
+                        "description": "Full REST catalog URL. Mutually exclusive with endpoint_type.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "endpoint_type": {
+                        "description": "Managed endpoint type. Mutually exclusive with endpoint.",
+                        "enum": [
+                          "GLUE",
+                          "S3_TABLES"
+                        ],
+                        "type": "string"
+                      },
+                      "max_table_staleness": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "purge_requested": {
+                        "type": "boolean"
+                      },
+                      "read_only": {
+                        "description": "Attach the catalog read-only. Read-write (read_only: false) on Horizon/Unity requires DuckDB 1.5.4 / duckdb-iceberg#1017.",
+                        "type": "boolean"
+                      },
+                      "remove_files_on_delete": {
+                        "description": "Remove underlying data files when a table is dropped (write-compat).",
+                        "type": "boolean"
+                      },
+                      "secret": {
+                        "description": "Name of a DuckDB secret from profiles.yml to use for authentication.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "skip_create_table_metadata_updates": {
+                        "description": "Skip metadata updates on CREATE TABLE (write-compat).",
+                        "type": "boolean"
+                      },
+                      "stage_create_tables": {
+                        "description": "Opt into staged CREATE TABLE AS SELECT writes (direct CTAS into the target catalog).",
+                        "type": "boolean"
+                      },
+                      "support_nested_namespaces": {
+                        "type": "boolean"
+                      },
+                      "support_stage_create": {
+                        "type": "boolean"
+                      },
+                      "warehouse": {
+                        "description": "S3 warehouse URI. Required when endpoint_type is S3_TABLES.",
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "snowflake": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "auto_refresh": {
+                        "type": "boolean"
+                      },
+                      "catalog_database": {
+                        "description": "Name of the Snowflake database linked to the external catalog.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "iceberg_version": {
+                        "description": "Iceberg spec version, e.g. 3 for Iceberg V3.",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "max_data_extension_time_in_days": {
+                        "description": "Days beyond the retention period to extend data availability. Range 0–90.",
+                        "maximum": 90,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "target_file_size": {
+                        "enum": [
+                          "AUTO",
+                          "16MB",
+                          "32MB",
+                          "64MB",
+                          "128MB"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "catalog_database"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Unique catalog name within this project.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "table_format": {
+                "const": "iceberg"
+              },
+              "type": {
+                "const": "glue"
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "table_format",
+              "config"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "description": "Iceberg REST catalog. Supports snowflake and/or duckdb connection blocks.",
+            "properties": {
+              "config": {
+                "additionalProperties": false,
+                "minProperties": 1,
+                "properties": {
+                  "alt": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "access_delegation_mode": {
+                        "enum": [
+                          "VENDED_CREDENTIALS",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "attach_as": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "authorization_type": {
+                        "enum": [
+                          "OAUTH2",
+                          "SIGV4",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "default_region": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "default_schema": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "disable_multi_table_commit": {
+                        "description": "Disable multi-table commits (Unity write-compat default).",
+                        "type": "boolean"
+                      },
+                      "encode_entire_prefix": {
+                        "type": "boolean"
+                      },
+                      "endpoint": {
+                        "description": "Full REST catalog URL. Mutually exclusive with endpoint_type.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "endpoint_type": {
+                        "description": "Managed endpoint type. Mutually exclusive with endpoint.",
+                        "enum": [
+                          "GLUE",
+                          "S3_TABLES"
+                        ],
+                        "type": "string"
+                      },
+                      "max_table_staleness": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "purge_requested": {
+                        "type": "boolean"
+                      },
+                      "read_only": {
+                        "description": "Attach the catalog read-only. Read-write (read_only: false) on Horizon/Unity requires DuckDB 1.5.4 / duckdb-iceberg#1017.",
+                        "type": "boolean"
+                      },
+                      "remove_files_on_delete": {
+                        "description": "Remove underlying data files when a table is dropped (write-compat).",
+                        "type": "boolean"
+                      },
+                      "secret": {
+                        "description": "Name of a DuckDB secret from profiles.yml to use for authentication.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "skip_create_table_metadata_updates": {
+                        "description": "Skip metadata updates on CREATE TABLE (write-compat).",
+                        "type": "boolean"
+                      },
+                      "stage_create_tables": {
+                        "description": "Opt into staged CREATE TABLE AS SELECT writes (direct CTAS into the target catalog).",
+                        "type": "boolean"
+                      },
+                      "support_nested_namespaces": {
+                        "type": "boolean"
+                      },
+                      "support_stage_create": {
+                        "type": "boolean"
+                      },
+                      "warehouse": {
+                        "description": "S3 warehouse URI. Required when endpoint_type is S3_TABLES.",
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "duckdb": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "access_delegation_mode": {
+                        "enum": [
+                          "VENDED_CREDENTIALS",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "attach_as": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "authorization_type": {
+                        "enum": [
+                          "OAUTH2",
+                          "SIGV4",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "default_region": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "default_schema": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "disable_multi_table_commit": {
+                        "description": "Disable multi-table commits (Unity write-compat default).",
+                        "type": "boolean"
+                      },
+                      "encode_entire_prefix": {
+                        "type": "boolean"
+                      },
+                      "endpoint": {
+                        "description": "Full REST catalog URL. Mutually exclusive with endpoint_type.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "endpoint_type": {
+                        "description": "Managed endpoint type. Mutually exclusive with endpoint.",
+                        "enum": [
+                          "GLUE",
+                          "S3_TABLES"
+                        ],
+                        "type": "string"
+                      },
+                      "max_table_staleness": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "purge_requested": {
+                        "type": "boolean"
+                      },
+                      "read_only": {
+                        "description": "Attach the catalog read-only. Read-write (read_only: false) on Horizon/Unity requires DuckDB 1.5.4 / duckdb-iceberg#1017.",
+                        "type": "boolean"
+                      },
+                      "remove_files_on_delete": {
+                        "description": "Remove underlying data files when a table is dropped (write-compat).",
+                        "type": "boolean"
+                      },
+                      "secret": {
+                        "description": "Name of a DuckDB secret from profiles.yml to use for authentication.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "skip_create_table_metadata_updates": {
+                        "description": "Skip metadata updates on CREATE TABLE (write-compat).",
+                        "type": "boolean"
+                      },
+                      "stage_create_tables": {
+                        "description": "Opt into staged CREATE TABLE AS SELECT writes (direct CTAS into the target catalog).",
+                        "type": "boolean"
+                      },
+                      "support_nested_namespaces": {
+                        "type": "boolean"
+                      },
+                      "support_stage_create": {
+                        "type": "boolean"
+                      },
+                      "warehouse": {
+                        "description": "S3 warehouse URI. Required when endpoint_type is S3_TABLES.",
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "snowflake": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "auto_refresh": {
+                        "type": "boolean"
+                      },
+                      "catalog_database": {
+                        "description": "Name of the Snowflake database linked to the external catalog.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "iceberg_version": {
+                        "description": "Iceberg spec version, e.g. 3 for Iceberg V3.",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "max_data_extension_time_in_days": {
+                        "description": "Days beyond the retention period to extend data availability. Range 0–90.",
+                        "maximum": 90,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "target_file_size": {
+                        "enum": [
+                          "AUTO",
+                          "16MB",
+                          "32MB",
+                          "64MB",
+                          "128MB"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "catalog_database"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Unique catalog name within this project.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "table_format": {
+                "const": "iceberg"
+              },
+              "type": {
+                "const": "iceberg_rest"
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "table_format",
+              "config"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "description": "Databricks Unity catalog. Supports snowflake, databricks, and/or duckdb (read-only attach) connection blocks.",
+            "properties": {
+              "config": {
+                "additionalProperties": false,
+                "minProperties": 1,
+                "properties": {
+                  "alt": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "access_delegation_mode": {
+                        "enum": [
+                          "VENDED_CREDENTIALS",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "attach_as": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "authorization_type": {
+                        "enum": [
+                          "OAUTH2",
+                          "SIGV4",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "default_region": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "default_schema": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "disable_multi_table_commit": {
+                        "description": "Disable multi-table commits (Unity write-compat default).",
+                        "type": "boolean"
+                      },
+                      "encode_entire_prefix": {
+                        "type": "boolean"
+                      },
+                      "endpoint": {
+                        "description": "Full REST catalog URL. Mutually exclusive with endpoint_type.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "endpoint_type": {
+                        "description": "Managed endpoint type. Mutually exclusive with endpoint.",
+                        "enum": [
+                          "GLUE",
+                          "S3_TABLES"
+                        ],
+                        "type": "string"
+                      },
+                      "max_table_staleness": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "purge_requested": {
+                        "type": "boolean"
+                      },
+                      "read_only": {
+                        "description": "Attach the catalog read-only. Read-write (read_only: false) on Horizon/Unity requires DuckDB 1.5.4 / duckdb-iceberg#1017.",
+                        "type": "boolean"
+                      },
+                      "remove_files_on_delete": {
+                        "description": "Remove underlying data files when a table is dropped (write-compat).",
+                        "type": "boolean"
+                      },
+                      "secret": {
+                        "description": "Name of a DuckDB secret from profiles.yml to use for authentication.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "skip_create_table_metadata_updates": {
+                        "description": "Skip metadata updates on CREATE TABLE (write-compat).",
+                        "type": "boolean"
+                      },
+                      "stage_create_tables": {
+                        "description": "Opt into staged CREATE TABLE AS SELECT writes (direct CTAS into the target catalog).",
+                        "type": "boolean"
+                      },
+                      "support_nested_namespaces": {
+                        "type": "boolean"
+                      },
+                      "support_stage_create": {
+                        "type": "boolean"
+                      },
+                      "warehouse": {
+                        "description": "S3 warehouse URI. Required when endpoint_type is S3_TABLES.",
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "databricks": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "catalog_database": {
+                        "description": "Name of the Databricks Unity Catalog to use as the database for models. When set, takes precedence over catalog name for database routing.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "file_format": {
+                        "enum": [
+                          "delta",
+                          "parquet"
+                        ],
+                        "type": "string"
+                      },
+                      "location_root": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "use_uniform": {
+                        "description": "UniForm mode. true requires file_format: delta; false (default) requires parquet.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "file_format"
+                    ],
+                    "type": "object"
+                  },
+                  "duckdb": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "access_delegation_mode": {
+                        "enum": [
+                          "VENDED_CREDENTIALS",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "attach_as": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "authorization_type": {
+                        "enum": [
+                          "OAUTH2",
+                          "SIGV4",
+                          "NONE"
+                        ],
+                        "type": "string"
+                      },
+                      "default_region": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "default_schema": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "disable_multi_table_commit": {
+                        "description": "Disable multi-table commits (Unity write-compat default).",
+                        "type": "boolean"
+                      },
+                      "encode_entire_prefix": {
+                        "type": "boolean"
+                      },
+                      "endpoint": {
+                        "description": "Full REST catalog URL. Mutually exclusive with endpoint_type.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "endpoint_type": {
+                        "description": "Managed endpoint type. Mutually exclusive with endpoint.",
+                        "enum": [
+                          "GLUE",
+                          "S3_TABLES"
+                        ],
+                        "type": "string"
+                      },
+                      "max_table_staleness": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "purge_requested": {
+                        "type": "boolean"
+                      },
+                      "read_only": {
+                        "description": "Attach the catalog read-only. Read-write (read_only: false) on Horizon/Unity requires DuckDB 1.5.4 / duckdb-iceberg#1017.",
+                        "type": "boolean"
+                      },
+                      "remove_files_on_delete": {
+                        "description": "Remove underlying data files when a table is dropped (write-compat).",
+                        "type": "boolean"
+                      },
+                      "secret": {
+                        "description": "Name of a DuckDB secret from profiles.yml to use for authentication.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "skip_create_table_metadata_updates": {
+                        "description": "Skip metadata updates on CREATE TABLE (write-compat).",
+                        "type": "boolean"
+                      },
+                      "stage_create_tables": {
+                        "description": "Opt into staged CREATE TABLE AS SELECT writes (direct CTAS into the target catalog).",
+                        "type": "boolean"
+                      },
+                      "support_nested_namespaces": {
+                        "type": "boolean"
+                      },
+                      "support_stage_create": {
+                        "type": "boolean"
+                      },
+                      "warehouse": {
+                        "description": "S3 warehouse URI. Required when endpoint_type is S3_TABLES.",
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "snowflake": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "auto_refresh": {
+                        "type": "boolean"
+                      },
+                      "catalog_database": {
+                        "description": "Name of the Snowflake database linked to the external catalog.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "iceberg_version": {
+                        "description": "Iceberg spec version, e.g. 3 for Iceberg V3.",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "max_data_extension_time_in_days": {
+                        "description": "Days beyond the retention period to extend data availability. Range 0–90.",
+                        "maximum": 90,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "target_file_size": {
+                        "enum": [
+                          "AUTO",
+                          "16MB",
+                          "32MB",
+                          "64MB",
+                          "128MB"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "catalog_database"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Unique catalog name within this project.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "table_format": {
+                "const": "iceberg"
+              },
+              "type": {
+                "const": "unity"
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "table_format",
+              "config"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "description": "Databricks Hive Metastore catalog. Databricks platform only.",
+            "properties": {
+              "config": {
+                "additionalProperties": false,
+                "properties": {
+                  "databricks": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "file_format": {
+                        "enum": [
+                          "delta",
+                          "parquet",
+                          "hudi"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "file_format"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "databricks"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "description": "Unique catalog name within this project.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "table_format": {
+                "const": "default"
+              },
+              "type": {
+                "const": "hive_metastore"
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "table_format",
+              "config"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "description": "BigLake Metastore catalog. BigQuery platform only.",
+            "properties": {
+              "config": {
+                "additionalProperties": false,
+                "properties": {
+                  "bigquery": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "base_location_root": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "catalog_database": {
+                        "description": "GCP project where models using this catalog should land. When set, takes precedence over model database config and target.database.",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "connection_id": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "external_volume": {
+                        "description": "Cloud Storage bucket path (gs://<bucket_name>).",
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "file_format": {
+                        "enum": [
+                          "parquet"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "external_volume",
+                      "file_format"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "bigquery"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "description": "Unique catalog name within this project.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "table_format": {
+                "const": "iceberg"
+              },
+              "type": {
+                "const": "biglake_metastore"
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "table_format",
+              "config"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "description": "DuckLake metadata store catalog. Supports duckdb and/or alt connection blocks.",
+            "properties": {
+              "config": {
+                "additionalProperties": false,
+                "minProperties": 1,
+                "properties": {
+                  "alt": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "attach_as": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "automatic_migration": {
+                        "type": "boolean"
+                      },
+                      "create_if_not_exists": {
+                        "type": "boolean"
+                      },
+                      "data_inlining_row_limit": {
+                        "description": "Inline row groups smaller than this many rows into the metadata catalog.",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "data_path": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "encrypted": {
+                        "type": "boolean"
+                      },
+                      "metadata_catalog": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "metadata_path": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "metadata_schema": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "override_data_path": {
+                        "type": "boolean"
+                      },
+                      "read_only": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "metadata_path"
+                    ],
+                    "type": "object"
+                  },
+                  "duckdb": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "attach_as": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "automatic_migration": {
+                        "type": "boolean"
+                      },
+                      "create_if_not_exists": {
+                        "type": "boolean"
+                      },
+                      "data_inlining_row_limit": {
+                        "description": "Inline row groups smaller than this many rows into the metadata catalog.",
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "data_path": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "encrypted": {
+                        "type": "boolean"
+                      },
+                      "metadata_catalog": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "metadata_path": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "metadata_schema": {
+                        "minLength": 1,
+                        "type": "string"
+                      },
+                      "override_data_path": {
+                        "type": "boolean"
+                      },
+                      "read_only": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "metadata_path"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "name": {
+                "description": "Unique catalog name within this project.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "table_format": {
+                "const": "default"
+              },
+              "type": {
+                "const": "ducklake"
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "table_format",
+              "config"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "description": "Local filesystem catalog. DuckDB platform only.",
+            "properties": {
+              "config": {
+                "additionalProperties": false,
+                "properties": {
+                  "duckdb": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "file_format": {
+                        "description": "Local file extension / DuckDB COPY format. Defaults to parquet.",
+                        "enum": [
+                          "parquet",
+                          "csv",
+                          "json"
+                        ],
+                        "type": "string"
+                      },
+                      "root_path": {
+                        "minLength": 1,
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "root_path"
+                    ],
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "duckdb"
+                ],
+                "type": "object"
+              },
+              "name": {
+                "description": "Unique catalog name within this project.",
+                "minLength": 1,
+                "type": "string"
+              },
+              "table_format": {
+                "const": "default"
+              },
+              "type": {
+                "const": "local_filesystem"
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "table_format",
+              "config"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "catalogs"
+  ],
+  "title": "DbtCatalogsFile",
+  "type": "object"
+}

--- a/schemas/latest_fusion/dbt_project-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_project-latest-fusion.json
@@ -470,6 +470,25 @@
         }
       ]
     },
+    "ComputePlatform": {
+      "description": "Selects the compute target a model's DML is executed against.\n\n`Default` uses the profile's adapter. A run implementation may honor an alternate target for other variants; parse/compile/render and introspection are unaffected by this selection.",
+      "oneOf": [
+        {
+          "description": "Execute on the profile's (default) adapter.",
+          "type": "string",
+          "enum": [
+            "default"
+          ]
+        },
+        {
+          "description": "Execute on the alternate compute target.",
+          "type": "string",
+          "enum": [
+            "alt"
+          ]
+        }
+      ]
+    },
     "DataLakeObjectCategory": {
       "description": "See `category` from https://developer.salesforce.com/docs/data/connectapi/references/spec?meta=postDataLakeObject",
       "type": "string",
@@ -741,6 +760,7 @@
     "FreshnessPeriod": {
       "type": "string",
       "enum": [
+        "second",
         "minute",
         "hour",
         "day"
@@ -1413,12 +1433,14 @@
         },
         "+hours_to_expiration": {
           "default": null,
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+immutable_where": {
           "type": [
@@ -1918,6 +1940,16 @@
             }
           ]
         },
+        "state-org-id": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "tenant_hostname": {
           "type": [
             "string",
@@ -2201,6 +2233,16 @@
             "null"
           ]
         },
+        "+alt_compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputePlatform"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "+as_columnstore": {
           "default": null,
           "type": [
@@ -2312,6 +2354,9 @@
             "boolean",
             "null"
           ]
+        },
+        "+classifiers": {
+          "$ref": "#/definitions/StringOrArrayOfStrings"
         },
         "+cluster_by": {
           "anyOf": [
@@ -2547,12 +2592,14 @@
         },
         "+hours_to_expiration": {
           "default": null,
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+http_path": {
           "type": [
@@ -2586,6 +2633,13 @@
           ]
         },
         "+include_full_name_in_path": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "+incremental_apply_config_changes": {
           "default": null,
           "type": [
             "boolean",
@@ -3245,6 +3299,13 @@
             "null"
           ]
         },
+        "+use_safer_relation_operations": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "+use_uniform": {
           "default": null,
           "type": [
@@ -3253,6 +3314,13 @@
           ]
         },
         "+user_folder_for_python": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "+view_update_via_alter": {
           "default": null,
           "type": [
             "boolean",
@@ -3559,12 +3627,14 @@
           ]
         },
         "+hours_to_expiration": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+immutable_where": {
           "type": [
@@ -3796,6 +3866,15 @@
             "string",
             "null"
           ]
+        },
+        "+resource_tags": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "+row_access_policy": {
           "type": [
@@ -4250,12 +4329,14 @@
         },
         "+hours_to_expiration": {
           "default": null,
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+immutable_where": {
           "type": [
@@ -4512,6 +4593,15 @@
             "string",
             "null"
           ]
+        },
+        "+resource_tags": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "+row_access_policy": {
           "type": [
@@ -4887,12 +4977,14 @@
         },
         "+hours_to_expiration": {
           "default": null,
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+include_full_name_in_path": {
           "default": null,
@@ -5372,12 +5464,14 @@
         },
         "+hours_to_expiration": {
           "default": null,
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "+immutable_where": {
           "type": [

--- a/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
+++ b/schemas/latest_fusion/dbt_yml_files-latest-fusion.json
@@ -404,6 +404,15 @@
         "name"
       ],
       "properties": {
+        "classifiers": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "column_mask": {
           "anyOf": [
             {
@@ -633,6 +642,25 @@
           "type": "string",
           "enum": [
             "service"
+          ]
+        }
+      ]
+    },
+    "ComputePlatform": {
+      "description": "Selects the compute target a model's DML is executed against.\n\n`Default` uses the profile's adapter. A run implementation may honor an alternate target for other variants; parse/compile/render and introspection are unaffected by this selection.",
+      "oneOf": [
+        {
+          "description": "Execute on the profile's (default) adapter.",
+          "type": "string",
+          "enum": [
+            "default"
+          ]
+        },
+        {
+          "description": "Execute on the alternate compute target.",
+          "type": "string",
+          "enum": [
+            "alt"
           ]
         }
       ]
@@ -1112,12 +1140,14 @@
           ]
         },
         "hours_to_expiration": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "iceberg_version": {
           "type": [
@@ -1134,6 +1164,12 @@
           ]
         },
         "include_full_name_in_path": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "incremental_apply_config_changes": {
           "type": [
             "boolean",
             "null"
@@ -1589,7 +1625,19 @@
             "null"
           ]
         },
+        "use_safer_relation_operations": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "use_uniform": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "view_update_via_alter": {
           "type": [
             "boolean",
             "null"
@@ -2409,6 +2457,7 @@
     "FreshnessPeriod": {
       "type": "string",
       "enum": [
+        "second",
         "minute",
         "hour",
         "day"
@@ -2737,12 +2786,14 @@
           ]
         },
         "hours_to_expiration": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "iceberg_version": {
           "type": [
@@ -2759,6 +2810,12 @@
           ]
         },
         "include_full_name_in_path": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "incremental_apply_config_changes": {
           "type": [
             "boolean",
             "null"
@@ -3206,7 +3263,19 @@
             }
           ]
         },
+        "use_safer_relation_operations": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "use_uniform": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "view_update_via_alter": {
           "type": [
             "boolean",
             "null"
@@ -4115,6 +4184,16 @@
             "null"
           ]
         },
+        "alt_compute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ComputePlatform"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "as_columnstore": {
           "type": [
             "boolean",
@@ -4218,6 +4297,17 @@
           "type": [
             "boolean",
             "null"
+          ]
+        },
+        "classifiers": {
+          "default": [],
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrArrayOfStrings"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "cluster_by": {
@@ -4446,12 +4536,14 @@
           ]
         },
         "hours_to_expiration": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "http_path": {
           "type": [
@@ -4484,6 +4576,12 @@
           ]
         },
         "include_full_name_in_path": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "incremental_apply_config_changes": {
           "type": [
             "boolean",
             "null"
@@ -5136,6 +5234,12 @@
             "null"
           ]
         },
+        "use_safer_relation_operations": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "use_uniform": {
           "type": [
             "boolean",
@@ -5143,6 +5247,12 @@
           ]
         },
         "user_folder_for_python": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "view_update_via_alter": {
           "type": [
             "boolean",
             "null"
@@ -6207,12 +6317,14 @@
           ]
         },
         "hours_to_expiration": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "iceberg_version": {
           "type": [
@@ -6229,6 +6341,12 @@
           ]
         },
         "include_full_name_in_path": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "incremental_apply_config_changes": {
           "type": [
             "boolean",
             "null"
@@ -6681,7 +6799,19 @@
             "null"
           ]
         },
+        "use_safer_relation_operations": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "use_uniform": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "view_update_via_alter": {
           "type": [
             "boolean",
             "null"
@@ -7085,12 +7215,14 @@
           ]
         },
         "hours_to_expiration": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "iceberg_version": {
           "type": [
@@ -7107,6 +7239,12 @@
           ]
         },
         "include_full_name_in_path": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "incremental_apply_config_changes": {
           "type": [
             "boolean",
             "null"
@@ -7621,7 +7759,19 @@
             "null"
           ]
         },
+        "use_safer_relation_operations": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "use_uniform": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "view_update_via_alter": {
           "type": [
             "boolean",
             "null"
@@ -7989,12 +8139,14 @@
           }
         },
         "hours_to_expiration": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "iceberg_version": {
           "type": [
@@ -8011,6 +8163,12 @@
           ]
         },
         "include_full_name_in_path": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "incremental_apply_config_changes": {
           "type": [
             "boolean",
             "null"
@@ -8434,7 +8592,19 @@
             "null"
           ]
         },
+        "use_safer_relation_operations": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "use_uniform": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "view_update_via_alter": {
           "type": [
             "boolean",
             "null"
@@ -8558,6 +8728,17 @@
           "items": {
             "type": "string"
           }
+        }
+      ]
+    },
+    "StringOrInteger": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer",
+          "format": "int64"
         }
       ]
     },
@@ -9031,12 +9212,14 @@
           }
         },
         "hours_to_expiration": {
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringOrInteger"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "iceberg_version": {
           "type": [
@@ -9053,6 +9236,12 @@
           ]
         },
         "include_full_name_in_path": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "incremental_apply_config_changes": {
           "type": [
             "boolean",
             "null"
@@ -9441,7 +9630,19 @@
             "null"
           ]
         },
+        "use_safer_relation_operations": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "use_uniform": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "view_update_via_alter": {
           "type": [
             "boolean",
             "null"

--- a/schemas/latest_fusion/profiles-latest-fusion.json
+++ b/schemas/latest_fusion/profiles-latest-fusion.json
@@ -1331,6 +1331,108 @@
           "additionalProperties": false
         },
         {
+          "description": "DuckDB adapter configuration",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "attach": {
+              "description": "External databases to attach.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/DuckDbAttachment"
+              }
+            },
+            "database": {
+              "description": "Database name (defaults to \"main\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "extensions": {
+              "description": "Extensions to load (e.g., [\"httpfs\", \"parquet\"] or [{name: \"duckpgq\", repo: \"community\"}])",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/DuckDbExtension"
+              }
+            },
+            "external_root": {
+              "description": "Root path for external materializations (defaults to \".\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "is_ducklake": {
+              "description": "Whether the primary database is a DuckLake database. Set to true to enable DuckLake-specific query generation (e.g., DROP without CASCADE). Not needed when the path uses the `ducklake:` scheme, but required for MotherDuck managed DuckLake where the path uses `md:` instead.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "path": {
+              "description": "Path to the DuckDB database file. Defaults to in-memory (:memory:)",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "schema": {
+              "description": "Schema name (defaults to \"main\")",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "secrets": {
+              "description": "Secrets to register with DuckDB's Secrets Manager.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "$ref": "#/definitions/DuckDbSecret"
+              }
+            },
+            "settings": {
+              "description": "DuckDB configuration settings (e.g., {\"memory_limit\": \"4GB\"})",
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": {
+                "$ref": "#/definitions/AnyValue"
+              }
+            },
+            "threads": {
+              "description": "Number of threads",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringOrInteger"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "alt"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {
           "type": "object",
           "required": [
             "type"


### PR DESCRIPTION
## Summary

This PR syncs the latest fusion JSON schemas from the dbt-fusion repository.

### Files Updated
- `schemas/latest_fusion/dbt_project-latest-fusion.json`
- `schemas/latest_fusion/dbt_yml_files-latest-fusion.json`
- `schemas/latest_fusion/selectors-latest-fusion.json`
- `schemas/latest_fusion/profiles-latest-fusion.json`
- `schemas/latest_fusion/dbt_cloud-latest-fusion.json`
- `schemas/latest_fusion/packages-latest-fusion.json`
- `schemas/latest_fusion/dependencies-latest-fusion.json`
- `schemas/latest_fusion/catalogs-latest-fusion.json`

---

### Source Information
- **Repository**: dbt-labs/fs
- **Ref**: project-bench-fixtures-v1-20260720
- **Commit**: [`b8f3f417e5af2dbdb59d6399c56ab1646801f149`](https://github.com/dbt-labs/fs/commit/b8f3f417e5af2dbdb59d6399c56ab1646801f149)
- **Workflow Run**: [View Run](https://github.com/dbt-labs/fs/actions/runs/29778331767)