### PR TITLE
fix: grant_access_to should use dataset (not database)

### DIFF
--- a/schemas/1.5/dbt_yml_files-1.5.json
+++ b/schemas/1.5/dbt_yml_files-1.5.json
@@ -926,12 +926,9 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": [
-              "database",
-              "project"
-            ],
+            "required": ["dataset", "project"],
             "properties": {
-              "database": {
+              "dataset": {
                 "type": "string"
               },
               "project": {

--- a/schemas/1.6/dbt_yml_files-1.6.json
+++ b/schemas/1.6/dbt_yml_files-1.6.json
@@ -1187,12 +1187,9 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": [
-              "database",
-              "project"
-            ],
+            "required": ["dataset", "project"],
             "properties": {
-              "database": {
+              "dataset": {
                 "type": "string"
               },
               "project": {

--- a/schemas/1.7/dbt_yml_files-1.7.json
+++ b/schemas/1.7/dbt_yml_files-1.7.json
@@ -1082,9 +1082,9 @@
           "description": "Configuration, specific to BigQuery adapter, used to setup authorized views.",
           "items": {
             "type": "object",
-            "required": ["database", "project"],
+            "required": ["dataset", "project"],
             "properties": {
-              "database": {
+              "dataset": {
                 "type": "string"
               },
               "project": {

--- a/schemas/dbt_yml_files.json
+++ b/schemas/dbt_yml_files.json
@@ -902,12 +902,9 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": [
-              "database",
-              "project"
-            ],
+            "required": ["dataset", "project"],
             "properties": {
-              "database": {
+              "dataset": {
                 "type": "string"
               },
               "project": {

--- a/schemas/latest/dbt_yml_files-latest.json
+++ b/schemas/latest/dbt_yml_files-latest.json
@@ -1960,12 +1960,9 @@
           "type": "array",
           "items": {
             "type": "object",
-            "required": [
-              "database",
-              "project"
-            ],
+            "required": ["dataset", "project"],
             "properties": {
-              "database": {
+              "dataset": {
                 "type": "string"
               },
               "project": {


### PR DESCRIPTION
## Summary
Fixes #158 — BigQuery `grant_access_to` docs use `project` + `dataset`, but parts of the JSON Schema still required/allowed `database`.

Restored after mistaken fork handling (detached/orphan backup). Equivalent to prior closed PR #260.

## Test plan
- [ ] Schema validates `grant_access_to: [{ project, dataset }]`
- [ ] `database` is no longer suggested for `grant_access_to` items in latest schema files